### PR TITLE
[codex] Align Sub2API flow with VPS parity

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,12 +188,18 @@ sub2api_mode:
   api_key: 
   min_accounts_threshold: 20
   batch_reg_count: 1
-  min_remaining_weekly_percent: 80
   remove_on_limit_reached: true
   remove_dead_accounts: true
   enable_token_revive: false
   check_interval_minutes: 60
   threads: 10
+  # Push settings for manually sending accounts to Sub2API
+  account_concurrency: 10
+  account_load_factor: 10
+  account_priority: 1
+  account_rate_multiplier: 1.0
+  account_group_ids: ""
+  enable_ws_mode: true
 
 hero_sms:
   enabled: false
@@ -221,4 +227,4 @@ web_password: admin
 #CF账号
 cf_api_email: 
 #CF KEY
-cf_api_key: 
+cf_api_key:

--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@
                                         <div><label class="form-label text-[11px] md:text-sm">巡检间隔(分)</label><input type="number" v-model.number="config.cpa_mode.check_interval_minutes" class="form-input text-sm"></div>
                                         <div><label class="form-label text-[11px] md:text-sm">测活并发数</label><input type="number" v-model.number="config.cpa_mode.threads" class="form-input text-sm"></div>
 
-                                        <div class="col-span-2 bg-red-50 p-3 md:p-5 rounded-xl border border-red-100 mt-1 md:mt-2 flex flex-col md:flex-row gap-4 md:gap-6">
+                                        <div class="col-span-2 bg-red-50 p-3 md:p-5 rounded-xl border border-red-100 mt-1 md:mt-2 flex flex-col md:flex-row gap-4 md:gap-6" data-mode="cpa">
                                             <div class="w-full md:w-1/3">
                                                 <label class="form-label text-red-800 font-bold text-xs md:text-sm">周限额剔除阈值(%)</label>
                                                 <input type="number" v-model.number="config.cpa_mode.min_remaining_weekly_percent" class="form-input border-red-300 font-black text-red-600 text-base md:text-xl text-center">
@@ -1034,12 +1034,69 @@
                                         <div><label class="form-label text-[11px] md:text-sm">巡检间隔(分)</label><input type="number" v-model.number="config.sub2api_mode.check_interval_minutes" class="form-input text-sm"></div>
                                         <div><label class="form-label text-[11px] md:text-sm">测活并发数</label><input type="number" v-model.number="config.sub2api_mode.threads" class="form-input text-sm"></div>
 
-                                        <div class="col-span-2 bg-red-50 p-3 md:p-5 rounded-xl border border-red-100 mt-1 md:mt-2 flex flex-col md:flex-row gap-4 md:gap-6">
-                                            <div class="w-full md:w-1/3">
-                                                <label class="form-label text-red-800 font-bold text-xs md:text-sm">周限额剔除阈值(%)</label>
-                                                <input type="number" v-model.number="config.sub2api_mode.min_remaining_weekly_percent" class="form-input border-red-300 font-black text-red-600 text-base md:text-xl text-center">
+                                        <div class="col-span-2 bg-purple-50 p-4 md:p-5 rounded-xl border border-purple-200 mt-1 space-y-4">
+                                            <h4 class="text-xs md:text-sm font-bold text-purple-800 flex items-center gap-2 pb-2 border-b border-purple-200">
+                                                <span>✨</span> 新账号推送参数
+                                            </h4>
+
+                                            <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
+                                                <div>
+                                                    <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold">并发数</label>
+                                                    <span class="text-[9px] text-purple-400 block mb-1">账号并发上限</span>
+                                                    <input type="number" min="1" v-model.number="config.sub2api_mode.account_concurrency" class="form-input border-purple-200 text-sm mb-0 font-mono">
+                                                </div>
+                                                <div>
+                                                    <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold">负载因子</label>
+                                                    <span class="text-[9px] text-purple-400 block mb-1">提高账号调度频率</span>
+                                                    <input type="number" min="1" v-model.number="config.sub2api_mode.account_load_factor" class="form-input border-purple-200 text-sm mb-0 font-mono">
+                                                </div>
+                                                <div>
+                                                    <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold">优先级</label>
+                                                    <span class="text-[9px] text-purple-400 block mb-1">数值越小越优先使用</span>
+                                                    <input type="number" min="1" v-model.number="config.sub2api_mode.account_priority" class="form-input border-purple-200 text-sm mb-0 font-mono">
+                                                </div>
+                                                <div>
+                                                    <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold">账号计费倍率</label>
+                                                    <span class="text-[9px] text-purple-400 block mb-1">0 = 不计费</span>
+                                                    <input type="number" step="0.1" min="0" v-model.number="config.sub2api_mode.account_rate_multiplier" class="form-input border-purple-200 text-sm mb-0 font-mono">
+                                                </div>
                                             </div>
-                                            <div class="w-full md:w-2/3 flex flex-col justify-center space-y-2 md:space-y-3">
+
+                                            <div>
+                                                <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold">WS mode</label>
+                                                <p class="text-[9px] text-purple-400 mb-1.5">仅对 OpenAI OAuth 账号生效。启用后并发数将作为该账号 WS 连接池上限。</p>
+                                                <select v-model="config.sub2api_mode.enable_ws_mode" class="form-input border-purple-200 bg-white font-bold text-purple-800 text-sm mb-0 max-w-xs">
+                                                    <option :value="false">关闭 (off)</option>
+                                                    <option :value="true">透传 (passthrough)</option>
+                                                </select>
+                                            </div>
+
+                                            <div>
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <label class="form-label text-[10px] md:text-xs text-purple-700 font-bold mb-0">绑定分组</label>
+                                                    <button @click="fetchSub2ApiGroups" :disabled="isLoadingSub2APIGroups"
+                                                            class="px-2.5 py-1 bg-purple-600 text-white text-[10px] md:text-xs font-bold rounded-lg hover:bg-purple-700 transition flex items-center gap-1 disabled:opacity-50 shadow-sm">
+                                                        <span :class="{'animate-spin inline-block': isLoadingSub2APIGroups}">{{ isLoadingSub2APIGroups ? '🔄' : '🔍' }}</span>
+                                                        {{ isLoadingSub2APIGroups ? '获取中...' : '获取分组' }}
+                                                    </button>
+                                                    <span v-if="config.sub2api_mode.account_group_ids" class="text-[10px] text-purple-500 font-mono bg-purple-100 rounded px-2 py-0.5">
+                                                        已选: {{ config.sub2api_mode.account_group_ids }}
+                                                    </span>
+                                                </div>
+                                                <div v-if="sub2apiGroups.length > 0" class="flex flex-wrap gap-2">
+                                                    <label v-for="group in sub2apiGroups" :key="group.id"
+                                                           class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border cursor-pointer transition text-xs font-bold select-none"
+                                                           :class="isGroupSelected(group.id) ? 'bg-purple-600 text-white border-purple-600 shadow-sm' : 'bg-white text-purple-700 border-purple-300 hover:bg-purple-50'">
+                                                        <input type="checkbox" class="sr-only" @change="toggleGroup(group.id)">
+                                                        {{ group.name }}
+                                                    </label>
+                                                </div>
+                                                <p v-else class="text-[10px] text-gray-400 italic">填写接口地址和 API Key 并保存后，点击「获取分组」</p>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-span-2 bg-red-50 p-3 md:p-5 rounded-xl border border-red-100 mt-1 md:mt-2 flex flex-col gap-3">
+                                            <div class="flex flex-col md:flex-row gap-3">
                                                 <label class="form-checkbox-label text-red-800 mb-0 bg-white p-1.5 md:p-2 rounded border border-red-100 items-center">
                                                     <input type="checkbox" v-model="config.sub2api_mode.remove_on_limit_reached" class="form-checkbox m-0 text-red-600">
                                                     <span class="text-[11px] md:text-sm font-bold ml-2">耗尽自动物理删除</span>
@@ -1052,11 +1109,11 @@
                                                     <input type="checkbox" v-model="config.sub2api_mode.enable_token_revive" class="form-checkbox m-0 text-blue-600">
                                                     <span class="text-[11px] md:text-sm font-bold ml-2">尝试 Token 复活</span>
                                                 </label>
-                                                <label class="form-checkbox-label text-cyan-800 mb-0 bg-cyan-50 p-1.5 md:p-2 rounded border border-cyan-100 items-center">
-                                                    <input type="checkbox" v-model="config.sub2api_mode.auto_check" class="form-checkbox m-0 text-cyan-600">
-                                                    <span class="text-[11px] md:text-sm font-bold ml-2">补货前自动巡检测活</span>
-                                                </label>
                                             </div>
+                                            <label class="form-checkbox-label text-cyan-800 mb-0 bg-cyan-50 p-1.5 md:p-2 rounded border border-cyan-100 items-center">
+                                                <input type="checkbox" v-model="config.sub2api_mode.auto_check" class="form-checkbox m-0 text-cyan-600">
+                                                <span class="text-[11px] md:text-sm font-bold ml-2">补货前自动巡检测活</span>
+                                            </label>
                                         </div>
                                     </div>
                                 </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -71,7 +71,9 @@ createApp({
             toasts: [],
             toastId: 0,
             confirmModal: { show: false, message: '', resolve: null },
-            updateInfo: { hasUpdate: false, version: '', url: '', changelog: '' }
+            updateInfo: { hasUpdate: false, version: '', url: '', changelog: '' },
+            sub2apiGroups: [],
+            isLoadingSub2APIGroups: false
         };
     },
     mounted() {
@@ -177,6 +179,27 @@ createApp({
 				
 				if (!this.config.sub_domain_level) {
                     this.config.sub_domain_level = 1;
+                }
+                if (!this.config.sub2api_mode) {
+                    this.config.sub2api_mode = {};
+                }
+                if (this.config.sub2api_mode.account_concurrency === undefined) {
+                    this.config.sub2api_mode.account_concurrency = 10;
+                }
+                if (this.config.sub2api_mode.account_load_factor === undefined) {
+                    this.config.sub2api_mode.account_load_factor = 10;
+                }
+                if (this.config.sub2api_mode.account_priority === undefined) {
+                    this.config.sub2api_mode.account_priority = 1;
+                }
+                if (this.config.sub2api_mode.account_rate_multiplier === undefined) {
+                    this.config.sub2api_mode.account_rate_multiplier = 1.0;
+                }
+                if (this.config.sub2api_mode.account_group_ids === undefined) {
+                    this.config.sub2api_mode.account_group_ids = '';
+                }
+                if (this.config.sub2api_mode.enable_ws_mode === undefined) {
+                    this.config.sub2api_mode.enable_ws_mode = true;
                 }
                 if(this.config.clash_proxy_pool && Array.isArray(this.config.clash_proxy_pool.blacklist)) {
                     this.blacklistStr = this.config.clash_proxy_pool.blacklist.join('\n');
@@ -789,6 +812,59 @@ createApp({
             } finally {
                 this.isManualBuying = false;
             }
+        },
+        async fetchSub2ApiGroups() {
+            if (!this.config || !this.config.sub2api_mode) return;
+            if (!this.config.sub2api_mode.api_url || !this.config.sub2api_mode.api_key) {
+                this.showToast('Please save the Sub2API URL and API key first.', 'warning');
+                return;
+            }
+
+            this.isLoadingSub2APIGroups = true;
+            try {
+                const res = await this.authFetch('/api/sub2api/groups');
+                const data = await res.json();
+                if (data.status === 'success') {
+                    const raw = data.data;
+                    let groups = [];
+                    if (Array.isArray(raw)) groups = raw;
+                    else if (raw && Array.isArray(raw.list)) groups = raw.list;
+                    else if (raw && Array.isArray(raw.data)) groups = raw.data;
+
+                    this.sub2apiGroups = groups;
+                    if (groups.length === 0) {
+                        this.showToast('No Sub2API groups found. Create one in Sub2API first.', 'warning');
+                    } else {
+                        this.showToast(`Fetched ${groups.length} Sub2API groups.`, 'success');
+                    }
+                } else {
+                    this.showToast(data.message || 'Failed to fetch Sub2API groups.', 'error');
+                }
+            } catch (e) {
+                this.showToast('Group fetch error: ' + e.message, 'error');
+            } finally {
+                this.isLoadingSub2APIGroups = false;
+            }
+        },
+        isGroupSelected(id) {
+            if (!this.config || !this.config.sub2api_mode) return false;
+            const ids = String(this.config.sub2api_mode.account_group_ids || '')
+                .split(',')
+                .map(s => s.trim())
+                .filter(s => s);
+            return ids.includes(String(id));
+        },
+        toggleGroup(id) {
+            if (!this.config || !this.config.sub2api_mode) return;
+            const ids = String(this.config.sub2api_mode.account_group_ids || '')
+                .split(',')
+                .map(s => s.trim())
+                .filter(s => s);
+            const value = String(id);
+            const index = ids.indexOf(value);
+            if (index >= 0) ids.splice(index, 1);
+            else ids.push(value);
+            this.config.sub2api_mode.account_group_ids = ids.join(',');
         },
         async startManualCheck() {
             if(this.isRunning) {

--- a/utils/config.py
+++ b/utils/config.py
@@ -135,11 +135,16 @@ SUB2API_BATCH_COUNT: int = 2
 SUB2API_CHECK_INTERVAL: int = 60
 SUB2API_THREADS: int = 10
 SUB2API_SAVE_TO_LOCAL: bool = True
-SUB2API_MIN_REMAINING_WEEKLY_PERCENT: int = 80
 SUB2API_REMOVE_ON_LIMIT_REACHED: bool = True
 SUB2API_REMOVE_DEAD_ACCOUNTS: bool = True
 SUB2API_ENABLE_TOKEN_REVIVE: bool = False
 SUB2API_AUTO_CHECK: bool = True
+SUB2API_ACCOUNT_CONCURRENCY: int = 10
+SUB2API_ACCOUNT_LOAD_FACTOR: int = 10
+SUB2API_ACCOUNT_PRIORITY: int = 1
+SUB2API_ACCOUNT_RATE_MULTIPLIER: float = 1.0
+SUB2API_ACCOUNT_GROUP_IDS: list = []
+SUB2API_ENABLE_WS_MODE: bool = True
 
 
 LUCKMAIL_PREFERRED_DOMAIN: str = ""
@@ -196,14 +201,59 @@ def reload_all_configs():
     global _clash_enable, _clash_pool_mode, WARP_PROXY_LIST, PROXY_QUEUE
     global ENABLE_SUB2API_MODE, SUB2API_URL, SUB2API_KEY
     global SUB2API_MIN_THRESHOLD, SUB2API_BATCH_COUNT, SUB2API_CHECK_INTERVAL, SUB2API_THREADS
-    global SUB2API_SAVE_TO_LOCAL, SUB2API_MIN_REMAINING_WEEKLY_PERCENT
+    global SUB2API_SAVE_TO_LOCAL
     global SUB2API_REMOVE_ON_LIMIT_REACHED, SUB2API_REMOVE_DEAD_ACCOUNTS, SUB2API_ENABLE_TOKEN_REVIVE
+    global SUB2API_ACCOUNT_CONCURRENCY, SUB2API_ACCOUNT_LOAD_FACTOR, SUB2API_ACCOUNT_PRIORITY
+    global SUB2API_ACCOUNT_RATE_MULTIPLIER, SUB2API_ACCOUNT_GROUP_IDS, SUB2API_ENABLE_WS_MODE
     global LUCKMAIL_API_KEY,LUCKMAIL_PREFERRED_DOMAIN,LUCKMAIL_EMAIL_TYPE,LUCKMAIL_VARIANT_MODE,LUCKMAIL_REUSE_PURCHASED, LUCKMAIL_TAG_ID
     global HERO_SMS_ENABLED, HERO_SMS_API_KEY, HERO_SMS_BASE_URL, HERO_SMS_COUNTRY, HERO_SMS_SERVICE
     global HERO_SMS_AUTO_PICK_COUNTRY, HERO_SMS_REUSE_PHONE, HERO_SMS_MAX_PRICE
     global HERO_SMS_MIN_BALANCE, HERO_SMS_MAX_TRIES, HERO_SMS_POLL_TIMEOUT_SEC
     global AI_API_BASE, AI_API_KEY, AI_MODEL, AI_ENABLE_PROFILE
     global CPA_AUTO_CHECK, SUB2API_AUTO_CHECK
+
+    def safe_int(value, default, minimum=None):
+        try:
+            parsed = int(str(value).strip())
+        except (TypeError, ValueError):
+            parsed = default
+        if minimum is not None:
+            return max(minimum, parsed)
+        return parsed
+
+    def safe_float(value, default, minimum=None):
+        try:
+            parsed = float(str(value).strip())
+        except (TypeError, ValueError):
+            parsed = default
+        if minimum is not None:
+            return max(minimum, parsed)
+        return parsed
+
+    def safe_bool(value, default=False):
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        text = str(value).strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off"}:
+            return False
+        return default
+
+    def parse_group_ids(raw_value):
+        if isinstance(raw_value, list):
+            raw_items = raw_value
+        else:
+            raw_items = str(raw_value or "").split(",")
+
+        group_ids = []
+        for item in raw_items:
+            text = str(item).strip()
+            if text.isdigit():
+                group_ids.append(int(text))
+        return group_ids
 
     _c = init_config()
 
@@ -266,11 +316,16 @@ def reload_all_configs():
     SUB2API_CHECK_INTERVAL = _sub2api.get("check_interval_minutes", 60)
     SUB2API_THREADS     = _sub2api.get("threads", 10)
     SUB2API_SAVE_TO_LOCAL = _sub2api.get("save_to_local", True)
-    SUB2API_MIN_REMAINING_WEEKLY_PERCENT = _sub2api.get("min_remaining_weekly_percent", 80)
     SUB2API_REMOVE_ON_LIMIT_REACHED = _sub2api.get("remove_on_limit_reached", True)
     SUB2API_REMOVE_DEAD_ACCOUNTS = _sub2api.get("remove_dead_accounts", True)
     SUB2API_ENABLE_TOKEN_REVIVE = _sub2api.get("enable_token_revive", False)
     SUB2API_AUTO_CHECK = _sub2api.get("auto_check", True)
+    SUB2API_ACCOUNT_CONCURRENCY = safe_int(_sub2api.get("account_concurrency", 10), 10, minimum=1)
+    SUB2API_ACCOUNT_LOAD_FACTOR = safe_int(_sub2api.get("account_load_factor", 10), 10, minimum=1)
+    SUB2API_ACCOUNT_PRIORITY = safe_int(_sub2api.get("account_priority", 1), 1, minimum=1)
+    SUB2API_ACCOUNT_RATE_MULTIPLIER = safe_float(_sub2api.get("account_rate_multiplier", 1.0), 1.0, minimum=0.0)
+    SUB2API_ACCOUNT_GROUP_IDS = parse_group_ids(_sub2api.get("account_group_ids", ""))
+    SUB2API_ENABLE_WS_MODE = safe_bool(_sub2api.get("enable_ws_mode", True), default=True)
 
     _normal          = _c.get("normal_mode", {})
     NORMAL_SLEEP_MIN = _normal.get("sleep_min", 5)

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -344,7 +344,7 @@ def test_sub2api_account_direct(item: dict, proxy: str) -> Tuple[bool, str]:
             
         data = resp.json()
         
-        reason = _extract_cliproxy_failure_reason(data, cfg.SUB2API_MIN_REMAINING_WEEKLY_PERCENT)
+        reason = _extract_cliproxy_failure_reason(data, 0)
         if reason:
             return False, reason
             
@@ -690,85 +690,77 @@ def _handle_sub2api_dead_account(item: dict, client: Any, is_disabled: bool) -> 
     account_id = item.get("id") 
 
     if cfg.SUB2API_REMOVE_DEAD_ACCOUNTS:
-        print(f"[{ts()}] [WARNING] 凭证 {mask_email(name)} 彻底死亡，执行物理剔除...")
+        print(f"[{ts()}] [ERROR] 凭证 {mask_email(name)} 彻底死亡，执行物理剔除...")
         if hasattr(client, "delete_account") and account_id:
             client.delete_account(account_id) 
     elif not is_disabled:
-        print(f"[{ts()}] [INFO] 凭证 {mask_email(name)} 死亡，根据配置保留，正在禁用...")
+        print(f"[{ts()}] [ERROR] 凭证 {mask_email(name)} 死亡，根据配置保留，正在禁用...")
         if hasattr(client, "set_account_status") and account_id:
             client.set_account_status(account_id, disabled=True)
     else:
-        print(f"[{ts()}] [WARNING] 凭证 {mask_email(name)} 已死亡，当前已是禁用状态，根据配置保留不删除。")
+        print(f"[{ts()}] [ERROR] 凭证 {mask_email(name)} 已死亡，当前已是禁用状态，根据配置保留不删除。")
 
 def process_sub2api_worker(i: int, total: int, item: dict, client: Any, args: Any) -> bool:
-    """专属 Sub2API 的测活 Worker"""
+    """Sub2API 测活 Worker（使用 Sub2API /test SSE 接口）"""
     if hasattr(args, 'check_stop') and args.check_stop(): return False
     name = item.get("name", "unknown")
     account_id = item.get("id")
-    is_disabled = item.get("status") != "active" 
-    
-    is_ok, msg = test_sub2api_account_direct(item, args.proxy)
-    if is_ok:
-        if is_disabled:
-            print(f"[{ts()}] [INFO] Sub2API测活: {mask_email(name)} 额度已恢复且有效，准备启用...")
-            if hasattr(client, "set_account_status") and account_id:
-                ok = client.set_account_status(account_id, disabled=False)
-                print(f"[{ts()}] [{'SUCCESS' if ok else 'ERROR'}] 凭证 {mask_email(name)} {'已成功启用！' if ok else '启用失败。'}")
-            return True
-        print(f"[{ts()}] [INFO] Sub2API测活: {mask_email(name)} 状态健康 ({msg})")
+    result, reason = client.test_account(account_id)
+
+    if result == "ok":
+        print(f"[{ts()}] [SUCCESS] Sub2API测活: {mask_email(name)} 状态健康")
         return True
 
-    print(f"[{ts()}] [WARNING] Sub2API测活: 凭证 {mask_email(name)} 失效，原因: {msg}")
-
-    if "周限额" in msg or "usage_limit_reached" in msg or "低于阈值" in msg:
+    if result == "quota":
         if cfg.SUB2API_REMOVE_ON_LIMIT_REACHED:
-            print(f"[{ts()}] [INFO] 真实测活触发限额剔除规则，执行物理剔除...")
-            if hasattr(client, "delete_account") and account_id:
+            print(f"[{ts()}] [WARNING] Sub2API测活: {mask_email(name)} 额度耗尽，执行物理删除...")
+            if account_id:
                 client.delete_account(account_id)
-        elif not is_disabled:
-            print(f"[{ts()}] [INFO] 真实测活显示额度耗尽，正在禁用...")
-            if hasattr(client, "set_account_status") and account_id:
-                client.set_account_status(account_id, disabled=True)
-        else:
-            print(f"[{ts()}] [INFO] 测活: 账号额度尚未恢复，继续保持禁用状态。")
+            return False
+        print(f"[{ts()}] [WARNING] Sub2API测活: {mask_email(name)} 额度限流，暂不计入有效库存，Sub2API 自动管理")
         return False
+
+    print(f"[{ts()}] [ERROR] Sub2API测活: {mask_email(name)} 测活失败 ({reason})")
 
     if not cfg.SUB2API_ENABLE_TOKEN_REVIVE:
-        print(f"[{ts()}] [INFO] 检测到 Token 已失效，但【复活】已关闭，仅记录状态。")
-        _handle_sub2api_dead_account(item, client, is_disabled)
+        print(f"[{ts()}] [ERROR] Token 复活已关闭，直接执行死亡处理")
+        _handle_sub2api_dead_account(item, client, is_disabled=False)
         return False
 
-    print(f"[{ts()}] [INFO] 测活: 凭证 {mask_email(name)} 准备尝试刷新 Token 复活...")
-    refresh_success = False
     refresh_token_val = item.get("credentials", {}).get("refresh_token")
-    
-    if refresh_token_val:
-        proxies = {"http": args.proxy, "https": args.proxy} if args.proxy else None
-        ok, new_tokens = refresh_oauth_token(refresh_token_val, proxies=proxies)
-        
-        if ok:
-            print(f"[{ts()}] [INFO] {mask_email(name)} Token 刷新成功，正在同步至 Sub2API...")
-            item.setdefault("credentials", {}).update(new_tokens)
-            
-            if hasattr(client, "update_account"):
-                up_ok, up_msg = client.update_account(account_id, item)
-                if up_ok:
-                    refresh_success = True
-                    print(f"[{ts()}] [SUCCESS] 测活: {mask_email(name)} 刷新后复活成功！")
-                else:
-                    print(f"[{ts()}] [ERROR] 刷新后覆盖 Sub2API 失败: {up_msg}")
-            else:
-                print(f"[{ts()}] [WARNING] 刷新成功，但缺少 update_account 接口方法")
-                refresh_success = True 
-        else:
-            print(f"[{ts()}] [WARNING] {mask_email(name)} Token 复活请求被拒绝: {new_tokens.get('error','未知')}")
-    else:
-        print(f"[{ts()}] [WARNING] {mask_email(name)} 未找到有效 refresh_token，无法抢救")
+    if not refresh_token_val:
+        print(f"[{ts()}] [ERROR] {mask_email(name)} 无 refresh_token，执行死亡处理")
+        _handle_sub2api_dead_account(item, client, is_disabled=False)
+        return False
 
-    if not refresh_success:
-        _handle_sub2api_dead_account(item, client, is_disabled)
-        
-    return refresh_success
+    print(f"[{ts()}] [INFO] {mask_email(name)} 尝试刷新 Token...")
+    proxies = {"http": args.proxy, "https": args.proxy} if args.proxy else None
+    ok, new_tokens = refresh_oauth_token(refresh_token_val, proxies=proxies)
+
+    if not ok:
+        err_info = new_tokens.get('error', '未知') if isinstance(new_tokens, dict) else str(new_tokens)
+        print(f"[{ts()}] [ERROR] {mask_email(name)} Token 刷新失败: {err_info}")
+        _handle_sub2api_dead_account(item, client, is_disabled=False)
+        return False
+
+    print(f"[{ts()}] [INFO] {mask_email(name)} Token 刷新成功，同步至 Sub2API...")
+    item.setdefault("credentials", {}).update(new_tokens)
+    up_ok, up_msg = client.update_account(account_id, item)
+    if not up_ok:
+        print(f"[{ts()}] [ERROR] {mask_email(name)} 更新回 Sub2API 失败: {up_msg}")
+        _handle_sub2api_dead_account(item, client, is_disabled=False)
+        return False
+
+    print(f"[{ts()}] [INFO] {mask_email(name)} Token 已更新，二次验证中...")
+    result2, reason2 = client.test_account(account_id)
+
+    if result2 == "ok":
+        print(f"[{ts()}] [SUCCESS] {mask_email(name)} 刷新复活成功，二次验证通过！")
+        return True
+
+    print(f"[{ts()}] [ERROR] {mask_email(name)} 二次验证失败 ({reason2})，账号确认已死")
+    _handle_sub2api_dead_account(item, client, is_disabled=False)
+    return False
 
 
 def normal_main_loop(args, stop_event: threading.Event):
@@ -884,12 +876,11 @@ async def perform_cpa_check(args, async_stop_event, loop):
 
 async def perform_sub2api_check(args, async_stop_event, loop, client):
     print(f"[{ts()}] [INFO] 开始执行 Sub2API 仓库全量测活巡检...")
-    success, data = client.get_accounts(page=1, page_size=1000)
+    success, account_list = client.get_all_accounts()
     if not success:
-        print(f"[{ts()}] [ERROR] 获取 Sub2API 库存失败: {data}")
+        print(f"[{ts()}] [ERROR] 获取 Sub2API 全量库存失败: {account_list}")
         return 0, 0
 
-    account_list = data.get("data", {}).get("items", [])
     total_files = len(account_list)
 
     with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as executor:
@@ -1042,11 +1033,7 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
     """Sub2API 智能仓管模式"""
     print("=" * 60)
     print(f"\n[{ts()}] [系统] Sub2API 目标库存阈值: {cfg.SUB2API_MIN_THRESHOLD} | 单次补发量: {cfg.SUB2API_BATCH_COUNT}")
-    print(
-        f"\n[{ts()}] [系统] 周限额剔除规则: 剩余低于 {cfg.SUB2API_MIN_REMAINING_WEEKLY_PERCENT}%"
-        if cfg.SUB2API_MIN_REMAINING_WEEKLY_PERCENT > 0
-        else f"\n[{ts()}] [系统] 周限额剔除规则: 完全耗尽才剔除"
-    )
+    print(f"\n[{ts()}] [系统] Sub2API 限额处理: 仅在真实耗尽后禁用或剔除")
     print("=" * 60)
 
     loop = asyncio.get_running_loop()
@@ -1055,14 +1042,13 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
     while not async_stop_event.is_set():
         print(f"\n[{ts()}] [INFO] 开始执行 Sub2API 仓库例行巡检与测活...")
         try:
-            success, data = client.get_accounts(page=1, page_size=1000)
+            success, account_list = client.get_all_accounts()
             if not success:
-                print(f"[{ts()}] [ERROR] 获取 Sub2API 库存失败: {data}")
+                print(f"[{ts()}] [ERROR] 获取 Sub2API 全量库存失败: {account_list}")
                 try: await asyncio.wait_for(async_stop_event.wait(), timeout=60)
                 except asyncio.TimeoutError: pass
                 continue
 
-            account_list = data.get("data", {}).get("items", [])
             total_files = len(account_list)
 
             with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as executor:

--- a/utils/sub2api_client.py
+++ b/utils/sub2api_client.py
@@ -1,10 +1,13 @@
+import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional, Tuple, List
+from typing import Any, Dict, List, Tuple
+
 from curl_cffi import requests as cffi_requests
 
 logger = logging.getLogger(__name__)
+
 
 class Sub2APIClient:
     def __init__(self, api_url: str, api_key: str):
@@ -15,17 +18,20 @@ class Sub2APIClient:
         }
         self.request_kwargs = {
             "timeout": 15,
-            "impersonate": "chrome110"
+            "impersonate": "chrome110",
         }
 
-    def _handle_response(self, response: cffi_requests.Response, success_codes: Tuple[int, ...] = (200, 201, 204)) -> Tuple[bool, Any]:
-        """统一处理响应结果"""
+    def _handle_response(
+        self,
+        response: cffi_requests.Response,
+        success_codes: Tuple[int, ...] = (200, 201, 204),
+    ) -> Tuple[bool, Any]:
         if response.status_code in success_codes:
             try:
                 return True, response.json() if response.text else {}
             except ValueError:
                 return True, response.text
-                
+
         error_msg = f"HTTP {response.status_code}"
         try:
             detail = response.json()
@@ -33,28 +39,81 @@ class Sub2APIClient:
                 error_msg = detail.get("message", error_msg)
         except Exception:
             error_msg = f"{error_msg} - {response.text[:200]}"
-            
+
         return False, error_msg
 
-    def get_accounts(self, page: int = 1, page_size: int = 50) -> Tuple[bool, Any]:
-        """获取账号列表"""
-        url = f"{self.api_url}/api/v1/admin/accounts"
-        params = {
-            "page": page,
-            "page_size": page_size
-        }
+    def _get_push_settings(self) -> Dict[str, Any]:
         try:
-            response = cffi_requests.get(url, headers=self.headers, params=params, **self.request_kwargs)
-            return self._handle_response(response)
-        except Exception as e:
-            logger.error(f"获取账号列表异常: {e}")
-            return False, str(e)
+            import utils.config as cfg
+        except ImportError:
+            cfg = None
 
-    def add_account(self, token_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """按照 Sub2API 要求的 sub2api-data 格式封装并上传"""
-        url = f"{self.api_url}/api/v1/admin/accounts/data" 
+        def as_int(value: Any, default: int, minimum: int) -> int:
+            try:
+                return max(minimum, int(value))
+            except (TypeError, ValueError):
+                return default
+
+        def as_float(value: Any, default: float, minimum: float) -> float:
+            try:
+                return max(minimum, float(value))
+            except (TypeError, ValueError):
+                return default
+
+        raw_group_ids = getattr(cfg, "SUB2API_ACCOUNT_GROUP_IDS", []) if cfg else []
+        if isinstance(raw_group_ids, list):
+            group_ids = [int(item) for item in raw_group_ids if str(item).strip().isdigit()]
+        else:
+            group_ids = [int(item.strip()) for item in str(raw_group_ids or "").split(",") if item.strip().isdigit()]
+
+        return {
+            "concurrency": as_int(getattr(cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10) if cfg else 10, 10, 1),
+            "load_factor": as_int(getattr(cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10) if cfg else 10, 10, 1),
+            "priority": as_int(getattr(cfg, "SUB2API_ACCOUNT_PRIORITY", 1) if cfg else 1, 1, 1),
+            "rate_multiplier": as_float(getattr(cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0) if cfg else 1.0, 1.0, 0.0),
+            "group_ids": group_ids,
+            "enable_ws": bool(getattr(cfg, "SUB2API_ENABLE_WS_MODE", True) if cfg else True),
+        }
+
+    def _build_account_extra(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        extra = {"load_factor": settings["load_factor"]}
+        if settings["enable_ws"]:
+            extra["openai_oauth_responses_websockets_v2_enabled"] = True
+            extra["openai_oauth_responses_websockets_v2_mode"] = "passthrough"
+        return extra
+
+    def _refresh_created_account(self, account_id: str) -> None:
+        if not account_id:
+            return
+
+        refresh_urls = [
+            f"{self.api_url}/api/v1/admin/accounts/{account_id}/refresh",
+            f"{self.api_url}/api/v1/admin/openai/accounts/{account_id}/refresh",
+        ]
+
+        for refresh_url in refresh_urls:
+            try:
+                response = cffi_requests.post(
+                    refresh_url,
+                    json={},
+                    headers=self.headers,
+                    timeout=30,
+                    impersonate="chrome110",
+                    proxies=None,
+                )
+                if response.status_code in (200, 201, 204):
+                    logger.info("Sub2API account refresh succeeded (ID: %s)", account_id)
+                    return
+            except Exception as exc:
+                logger.warning("Sub2API account refresh failed via %s: %s", refresh_url, exc)
+
+        logger.warning("Sub2API account refresh did not succeed for %s", account_id)
+
+    def _import_account(self, token_data: Dict[str, Any], settings: Dict[str, Any]) -> Tuple[bool, str]:
+        url = f"{self.api_url}/api/v1/admin/accounts/data"
         exported_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        
+        extra = self._build_account_extra(settings)
+
         account_item = {
             "name": token_data.get("email", "unknown"),
             "platform": "openai",
@@ -63,21 +122,24 @@ class Sub2APIClient:
                 "access_token": token_data.get("access_token", ""),
                 "chatgpt_account_id": token_data.get("account_id", ""),
                 "client_id": token_data.get("client_id", ""),
-                "expires_at": int(time.time() + 864000), 
+                "expires_at": int(time.time() + 864000),
                 "expires_in": 863999,
                 "model_mapping": {
                     "gpt-4o": "gpt-4o",
                     "gpt-4": "gpt-4",
-                    "gpt-3.5-turbo": "gpt-3.5-turbo"
+                    "gpt-3.5-turbo": "gpt-3.5-turbo",
                 },
                 "organization_id": token_data.get("workspace_id", ""),
                 "refresh_token": token_data.get("refresh_token", ""),
             },
-            "extra": {},
-            "concurrency": 3,
-            "priority": 50,
+            "extra": extra,
+            "concurrency": settings["concurrency"],
+            "priority": settings["priority"],
+            "rate_multiplier": settings["rate_multiplier"],
             "auto_pause_on_expired": True,
         }
+        if settings["group_ids"]:
+            account_item["group_ids"] = settings["group_ids"]
 
         payload = {
             "data": {
@@ -87,73 +149,226 @@ class Sub2APIClient:
                 "proxies": [],
                 "accounts": [account_item],
             },
-            "skip_default_group_bind": True,
+            "skip_default_group_bind": not bool(settings["group_ids"]),
         }
 
         try:
             headers = self.headers.copy()
             headers["Idempotency-Key"] = f"import-{int(time.time())}"
-            
             response = cffi_requests.post(
-                url, 
-                json=payload, 
-                headers=headers, 
-                timeout=30, 
+                url,
+                json=payload,
+                headers=headers,
+                timeout=30,
                 impersonate="chrome110",
-                proxies=None
+                proxies=None,
             )
-            return self._handle_response(response, success_codes=(200, 201))
-        except Exception as e:
-            return False, f"网络请求异常: {str(e)}"
+            ok, result = self._handle_response(response, success_codes=(200, 201))
+            if ok:
+                return True, "Sub2API account import succeeded"
+            return False, str(result)
+        except Exception as exc:
+            return False, f"Network request failed: {exc}"
+
+    def get_accounts(self, page: int = 1, page_size: int = 50) -> Tuple[bool, Any]:
+        url = f"{self.api_url}/api/v1/admin/accounts"
+        params = {
+            "page": page,
+            "page_size": page_size,
+        }
+        try:
+            response = cffi_requests.get(url, headers=self.headers, params=params, **self.request_kwargs)
+            return self._handle_response(response)
+        except Exception as exc:
+            logger.error("Get Sub2API accounts failed: %s", exc)
+            return False, str(exc)
+
+    def get_all_accounts(self, page_size: int = 100) -> Tuple[bool, Any]:
+        all_items: List[dict] = []
+        page = 1
+
+        while True:
+            ok, data = self.get_accounts(page=page, page_size=page_size)
+            if not ok:
+                if page == 1:
+                    return False, data
+                logger.warning(
+                    "Sub2API pagination failed on page %s; continue with %s fetched accounts",
+                    page,
+                    len(all_items),
+                )
+                break
+
+            inner = data.get("data", {}) if isinstance(data, dict) else {}
+            items = inner.get("items", [])
+            if not items:
+                break
+
+            all_items.extend(items)
+
+            total = inner.get("total", 0)
+            if len(all_items) >= total:
+                break
+
+            page += 1
+
+        logger.info("Fetched %s Sub2API accounts across paginated results", len(all_items))
+        return True, all_items
+
+    def add_account(self, token_data: Dict[str, Any]) -> Tuple[bool, str]:
+        settings = self._get_push_settings()
+        refresh_token = token_data.get("refresh_token", "")
+
+        if not refresh_token:
+            return self._import_account(token_data, settings)
+
+        url = f"{self.api_url}/api/v1/admin/accounts"
+        payload = {
+            "name": token_data.get("email", "unknown"),
+            "platform": "openai",
+            "type": "oauth",
+            "credentials": {"refresh_token": refresh_token},
+            "concurrency": settings["concurrency"],
+            "priority": settings["priority"],
+            "rate_multiplier": settings["rate_multiplier"],
+            "extra": self._build_account_extra(settings),
+        }
+        if settings["group_ids"]:
+            payload["group_ids"] = settings["group_ids"]
+
+        try:
+            response = cffi_requests.post(
+                url,
+                json=payload,
+                headers=self.headers,
+                timeout=30,
+                impersonate="chrome110",
+                proxies=None,
+            )
+            ok, result = self._handle_response(response, success_codes=(200, 201))
+            if not ok:
+                logger.warning("Sub2API direct create failed, falling back to import endpoint: %s", result)
+                return self._import_account(token_data, settings)
+
+            account_id = result.get("data", {}).get("id") if isinstance(result, dict) else None
+            if account_id:
+                self._refresh_created_account(str(account_id))
+            return True, "Sub2API account created successfully"
+        except Exception as exc:
+            logger.warning("Sub2API direct create raised an exception, falling back to import: %s", exc)
+            return self._import_account(token_data, settings)
 
     def update_account(self, account_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Any]:
-        """更新指定账号"""
         url = f"{self.api_url}/api/v1/admin/accounts/{account_id}"
         try:
             response = cffi_requests.put(url, json=update_data, headers=self.headers, **self.request_kwargs)
             return self._handle_response(response)
-        except Exception as e:
-            logger.error(f"更新账号 {account_id} 异常: {e}")
-            return False, str(e)
+        except Exception as exc:
+            logger.error("Update Sub2API account %s failed: %s", account_id, exc)
+            return False, str(exc)
+
+    def set_account_status(self, account_id: str, disabled: bool) -> bool:
+        url = f"{self.api_url}/api/v1/admin/accounts/{account_id}"
+        payload = {"disabled": disabled}
+        try:
+            response = cffi_requests.patch(url, json=payload, headers=self.headers, **self.request_kwargs)
+            if response.status_code in (200, 201, 204):
+                return True
+            response = cffi_requests.put(url, json=payload, headers=self.headers, **self.request_kwargs)
+            return response.status_code in (200, 201, 204)
+        except Exception as exc:
+            logger.error("Set Sub2API account %s status failed: %s", account_id, exc)
+            return False
 
     def delete_account(self, account_id: str) -> Tuple[bool, Any]:
-        """删除指定账号"""
         url = f"{self.api_url}/api/v1/admin/accounts/{account_id}"
         try:
             response = cffi_requests.delete(url, headers=self.headers, **self.request_kwargs)
             return self._handle_response(response, success_codes=(200, 204))
-        except Exception as e:
-            logger.error(f"删除账号 {account_id} 异常: {e}")
-            return False, str(e)
+        except Exception as exc:
+            logger.error("Delete Sub2API account %s failed: %s", account_id, exc)
+            return False, str(exc)
 
     def refresh_account(self, account_id: str) -> Tuple[bool, Any]:
-        """触发账号状态检查/刷新"""
         url = f"{self.api_url}/api/v1/admin/accounts/{account_id}/refresh"
         try:
             response = cffi_requests.post(url, headers=self.headers, json={}, **self.request_kwargs)
             return self._handle_response(response)
-        except Exception as e:
-            logger.error(f"刷新账号 {account_id} 异常: {e}")
-            return False, str(e)
+        except Exception as exc:
+            logger.error("Refresh Sub2API account %s failed: %s", account_id, exc)
+            return False, str(exc)
+
+    def test_account(self, account_id: int) -> Tuple[str, str]:
+        url = f"{self.api_url}/api/v1/admin/accounts/{account_id}/test"
+        try:
+            response = cffi_requests.post(
+                url,
+                headers=self.headers,
+                json={},
+                timeout=60,
+                impersonate="chrome110",
+            )
+            if response.status_code != 200:
+                logger.warning("Sub2API test_account %s returned HTTP %s; keep current state", account_id, response.status_code)
+                return "ok", f"HTTP {response.status_code}, skipped"
+
+            for line in response.text.splitlines():
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+
+                raw = line[5:].strip()
+                if not raw or raw == "[DONE]":
+                    continue
+
+                try:
+                    event = json.loads(raw)
+                except Exception:
+                    continue
+
+                event_type = event.get("type", "")
+                if event_type == "test_complete":
+                    if event.get("success"):
+                        return "ok", "test completed"
+                    err = str(event.get("error") or event.get("text") or "")
+                    return _classify_sse_error(err)
+
+                if event_type == "error":
+                    err = str(event.get("error") or event.get("text") or "")
+                    return _classify_sse_error(err)
+
+            logger.warning("Sub2API test_account %s did not emit a terminal SSE event; keep current state", account_id)
+            return "ok", "no terminal SSE event, skipped"
+        except Exception as exc:
+            logger.warning("Sub2API test_account %s failed: %s", account_id, exc)
+            return "ok", f"test error, skipped: {str(exc)[:120]}"
 
     def test_connection(self) -> Tuple[bool, str]:
-        """测试 Sub2API 连接"""
         url = f"{self.api_url}/api/v1/admin/accounts/data"
         try:
             kwargs = self.request_kwargs.copy()
-            kwargs["timeout"] = 10 
+            kwargs["timeout"] = 10
             response = cffi_requests.get(url, headers=self.headers, **kwargs)
 
             if response.status_code in (200, 201, 204, 405):
-                return True, "Sub2API 连接测试成功，API Key 有效"
+                return True, "Sub2API connection test succeeded. The API key is valid."
             if response.status_code == 401:
-                return False, "连接成功，但 API Key 无效 (401 Unauthorized)"
+                return False, "Connected, but the API key is invalid (401 Unauthorized)."
             if response.status_code == 403:
-                return False, "连接成功，但权限不足 (403 Forbidden)"
-            return False, f"服务器返回异常状态码: {response.status_code}"
-        except cffi_requests.exceptions.ConnectionError as e:
-            return False, f"无法连接到服务器: {str(e)}"
+                return False, "Connected, but the API key does not have enough permission (403 Forbidden)."
+            return False, f"Unexpected server status code: {response.status_code}"
+        except cffi_requests.exceptions.ConnectionError as exc:
+            return False, f"Could not connect to the Sub2API server: {exc}"
         except cffi_requests.exceptions.Timeout:
-            return False, "连接超时，请检查网络配置或服务器状态"
-        except Exception as e:
-            return False, f"连接测试失败: {str(e)}"
+            return False, "Connection timed out. Check the network or server status."
+        except Exception as exc:
+            return False, f"Sub2API connection test failed: {exc}"
+
+
+def _classify_sse_error(err_text: str) -> Tuple[str, str]:
+    text = err_text.lower()
+    if any(keyword in text for keyword in ("429", "rate_limit", "rate limit", "too many request")):
+        return "quota", f"quota limited: {err_text[:120]}"
+    if err_text.strip():
+        return "dead", f"test failed: {err_text[:120]}"
+    return "ok", "empty SSE error, skipped"

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -263,12 +263,16 @@ async def get_config(token: str = Depends(verify_token)):
     if os.path.exists(CONFIG_PATH):
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f) or {}
+    if isinstance(config_data.get("sub2api_mode"), dict):
+        config_data["sub2api_mode"].pop("min_remaining_weekly_percent", None)
     config_data["web_password"] = config_data.get("web_password", "admin")
     return config_data
 
 @app.post("/api/config")
 async def save_config(new_config: dict, token: str = Depends(verify_token)):
     try:
+        if isinstance(new_config.get("sub2api_mode"), dict):
+            new_config["sub2api_mode"].pop("min_remaining_weekly_percent", None)
         with core_engine.cfg.CONFIG_FILE_LOCK:
             with open(CONFIG_PATH, "w", encoding="utf-8") as f:
                 yaml.dump(new_config, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
@@ -726,6 +730,33 @@ async def start_check_api(token: str = Depends(verify_token)):
     args = DummyArgs(proxy=default_proxy if default_proxy else None)
     engine.start_check(args)
     return {"code": 200, "message": "独立测活指令已下发！"}
+
+@app.get("/api/sub2api/groups")
+async def get_sub2api_groups(token: str = Depends(verify_token)):
+    from curl_cffi import requests as cffi_requests
+
+    sub2api_url = getattr(core_engine.cfg, "SUB2API_URL", "").strip()
+    sub2api_key = getattr(core_engine.cfg, "SUB2API_KEY", "").strip()
+    if not sub2api_url or not sub2api_key:
+        return {"status": "error", "message": "Please save the Sub2API URL and API key first."}
+
+    try:
+        response = cffi_requests.get(
+            f"{sub2api_url.rstrip('/')}/api/v1/admin/groups/all",
+            headers={"x-api-key": sub2api_key, "Content-Type": "application/json"},
+            timeout=10,
+            impersonate="chrome110",
+        )
+        if response.status_code != 200:
+            return {"status": "error", "message": f"HTTP {response.status_code}: {response.text[:200]}"}
+
+        payload = response.json()
+        groups = payload.get("data", [])
+        if not isinstance(groups, list):
+            groups = []
+        return {"status": "success", "data": groups}
+    except Exception as exc:
+        return {"status": "error", "message": f"Failed to fetch Sub2API groups: {exc}"}
 
 if __name__ == "__main__":
     try: reload_all_configs()


### PR DESCRIPTION
﻿## What changed
- aligned Sub2API account push with the VPS workflow, including push parameters for concurrency, load factor, priority, rate multiplier, groups, and WS mode
- added Sub2API group fetching/switching support and a backend `/api/sub2api/groups` proxy endpoint
- switched Sub2API liveness checks to use the Sub2API `/test` flow, kept quota handling under Sub2API management, and added full pagination for account scans
- removed the Sub2API weekly-threshold config and UI while keeping the CPA threshold logic intact
- updated log levels so healthy accounts are green, quota-limited accounts are yellow, and failures are red in the UI

## Why
The latest upstream release already had basic Sub2API support, but it was missing several VPS behaviors that are relied on in real deployments. This change brings the newer codebase closer to the VPS behavior without carrying over unrelated local-only deployment changes.

## Validation
- `python -m py_compile utils/config.py utils/sub2api_client.py utils/core_engine.py wfxl_openai_regst.py`
- `docker compose up -d --build codex-web`
- `Invoke-WebRequest http://127.0.0.1:8000/` returned `200`
