### PR TITLE
Mark Microsoft abuse-mode mailboxes dead

### DIFF
--- a/tests/test_local_microsoft_service_abuse_mode.py
+++ b/tests/test_local_microsoft_service_abuse_mode.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 fake_requests_module = types.SimpleNamespace(post=None, get=None)
 sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
 
-from utils.email_providers.local_microsoft_service import LocalMicrosoftService
+from utils.email_providers.local_microsoft_service import LocalMicrosoftService, MailboxAbuseModeError
 
 
 class _FakeResponse:
@@ -57,11 +57,32 @@ class LocalMicrosoftServiceAbuseModeTests(unittest.TestCase):
                 "utils.email_providers.local_microsoft_service.db_manager.update_local_mailbox_status"
             ) as update_status:
                 with redirect_stdout(io.StringIO()):
-                    with self.assertRaises(RuntimeError) as ctx:
+                    with self.assertRaises(MailboxAbuseModeError) as ctx:
                         service._exchange_refresh_token(mailbox)
 
-        self.assertIn("AADSTS70000", str(ctx.exception))
+        self.assertIn("service abuse mode", str(ctx.exception))
         update_status.assert_called_once_with("user@example.com", 3)
+
+    def test_fetch_openai_messages_logs_warning_instead_of_debug_for_service_abuse(self):
+        service = LocalMicrosoftService()
+        mailbox = {
+            "email": "user+alias@example.com",
+            "master_email": "user@example.com",
+        }
+
+        with patch.object(
+            service,
+            "_exchange_refresh_token",
+            side_effect=MailboxAbuseModeError("user@example.com"),
+        ):
+            captured = io.StringIO()
+            with redirect_stdout(captured):
+                messages = service.fetch_openai_messages(mailbox)
+
+        self.assertEqual([], messages)
+        output = captured.getvalue()
+        self.assertIn("service abuse mode", output)
+        self.assertNotIn("[DEBUG-GRAPH]", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_local_microsoft_service_abuse_mode.py
+++ b/tests/test_local_microsoft_service_abuse_mode.py
@@ -1,0 +1,68 @@
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+fake_requests_module = types.SimpleNamespace(post=None, get=None)
+sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
+
+from utils.email_providers.local_microsoft_service import LocalMicrosoftService
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class LocalMicrosoftServiceAbuseModeTests(unittest.TestCase):
+    def test_service_abuse_mode_marks_master_mailbox_dead(self):
+        service = LocalMicrosoftService()
+        mailbox = {
+            "email": "user+alias@example.com",
+            "master_email": "user@example.com",
+            "refresh_token": "refresh-token",
+            "client_id": "client-id",
+        }
+        responses = [
+            _FakeResponse(
+                400,
+                {
+                    "error": "invalid_scope",
+                    "error_description": "AADSTS70000 invalid_scope",
+                },
+            ),
+            _FakeResponse(
+                400,
+                {
+                    "error": "invalid_grant",
+                    "error_description": "AADSTS70000: User account is found to be in service abuse mode.",
+                },
+            ),
+        ]
+
+        def fake_post(*args, **kwargs):
+            return responses.pop(0)
+
+        with patch(
+            "utils.email_providers.local_microsoft_service.cffi_requests.post",
+            side_effect=fake_post,
+        ):
+            with patch(
+                "utils.email_providers.local_microsoft_service.db_manager.update_local_mailbox_status"
+            ) as update_status:
+                with redirect_stdout(io.StringIO()):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        service._exchange_refresh_token(mailbox)
+
+        self.assertIn("AADSTS70000", str(ctx.exception))
+        update_status.assert_called_once_with("user@example.com", 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_microsoft_service_abuse_mode.py
+++ b/tests/test_local_microsoft_service_abuse_mode.py
@@ -80,6 +80,7 @@ class LocalMicrosoftServiceAbuseModeTests(unittest.TestCase):
                 messages = service.fetch_openai_messages(mailbox)
 
         self.assertEqual([], messages)
+        self.assertEqual("abuse_mode", mailbox.get("_polling_stopped"))
         output = captured.getvalue()
         self.assertIn("service abuse mode", output)
         self.assertNotIn("[DEBUG-GRAPH]", output)

--- a/tests/test_mail_service_abuse_mode.py
+++ b/tests/test_mail_service_abuse_mode.py
@@ -1,0 +1,61 @@
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+fake_requests_module = types.SimpleNamespace(post=None, get=None)
+sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
+sys.modules.setdefault(
+    "utils.integrations.ai_service",
+    types.SimpleNamespace(AIService=object),
+)
+sys.modules.setdefault(
+    "utils.email_providers.gmail_service",
+    types.SimpleNamespace(get_gmail_otp_via_oauth=lambda *args, **kwargs: ""),
+)
+sys.modules.setdefault(
+    "utils.email_providers.duckmail_service",
+    types.SimpleNamespace(DuckMailService=object),
+)
+
+from utils.email_providers.mail_service import _poll_local_ms_for_oai_code_graph
+
+
+class _AbuseStopService:
+    def __init__(self):
+        self.calls = 0
+
+    def fetch_openai_messages(self, mailbox):
+        self.calls += 1
+        mailbox["_polling_stopped"] = "abuse_mode"
+        return []
+
+
+class MailServiceAbuseModeTests(unittest.TestCase):
+    def test_graph_poll_stops_immediately_after_mailbox_enters_abuse_mode(self):
+        service = _AbuseStopService()
+        mailbox = {
+            "email": "user+alias@example.com",
+            "master_email": "user@example.com",
+            "assigned_at": 0,
+        }
+
+        with patch("utils.email_providers.mail_service.time.sleep") as sleep_mock:
+            with redirect_stdout(io.StringIO()):
+                code = _poll_local_ms_for_oai_code_graph(
+                    ms_service=service,
+                    target_email="user+alias@example.com",
+                    mailbox_dict=mailbox,
+                    max_attempts=5,
+                )
+
+        self.assertEqual("", code)
+        self.assertEqual("abuse_mode", mailbox.get("_polling_stopped"))
+        self.assertEqual(1, service.calls)
+        sleep_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/email_providers/local_microsoft_service.py
+++ b/utils/email_providers/local_microsoft_service.py
@@ -176,6 +176,7 @@ class LocalMicrosoftService:
             else:
                 print(f"[{cfg.ts()}] [ERROR] 扫信接口请求失败: {resp.status_code} | {resp.text}")
         except MailboxAbuseModeError as e:
+            mailbox["_polling_stopped"] = "abuse_mode"
             print(str(e), flush=True)
         except Exception as e:
             print(f"[{cfg.ts()}] [DEBUG-GRAPH] 扫信模块严重错误: {e}", flush=True)

--- a/utils/email_providers/local_microsoft_service.py
+++ b/utils/email_providers/local_microsoft_service.py
@@ -14,6 +14,13 @@ from utils import config as cfg
 from utils import db_manager
 _fission_lock = threading.Lock()
 
+
+class MailboxAbuseModeError(RuntimeError):
+    def __init__(self, email: str):
+        super().__init__(f"[{cfg.ts()}] [WARNING] Microsoft 邮箱已进入 service abuse mode，已自动停用: {email}")
+        self.email = email
+
+
 class LocalMicrosoftService:
     def __init__(self, proxies: Optional[Dict[str, str]] = None):
         self.proxies = proxies
@@ -135,6 +142,7 @@ class LocalMicrosoftService:
                         db_manager.update_local_mailbox_status(target_email, 3)
                     except:
                         pass
+                    raise MailboxAbuseModeError(target_email)
             raise RuntimeError(f"[{cfg.ts()}] [ERROR] 双令牌模式尝试均失败: {err_msg}")
 
     def fetch_openai_messages(self, mailbox: dict) -> List[Dict[str, Any]]:
@@ -167,6 +175,8 @@ class LocalMicrosoftService:
                 return all_msgs
             else:
                 print(f"[{cfg.ts()}] [ERROR] 扫信接口请求失败: {resp.status_code} | {resp.text}")
+        except MailboxAbuseModeError as e:
+            print(str(e), flush=True)
         except Exception as e:
             print(f"[{cfg.ts()}] [DEBUG-GRAPH] 扫信模块严重错误: {e}", flush=True)
         return all_msgs

--- a/utils/email_providers/local_microsoft_service.py
+++ b/utils/email_providers/local_microsoft_service.py
@@ -127,6 +127,14 @@ class LocalMicrosoftService:
             return data["access_token"]
         else:
             err_msg = data.get('error_description', data)
+            err_text = str(err_msg)
+            if "AADSTS70000" in err_text and "service abuse mode" in err_text.lower():
+                target_email = mailbox.get("master_email") or mailbox.get("email")
+                if target_email:
+                    try:
+                        db_manager.update_local_mailbox_status(target_email, 3)
+                    except:
+                        pass
             raise RuntimeError(f"[{cfg.ts()}] [ERROR] 双令牌模式尝试均失败: {err_msg}")
 
     def fetch_openai_messages(self, mailbox: dict) -> List[Dict[str, Any]]:

--- a/utils/email_providers/mail_service.py
+++ b/utils/email_providers/mail_service.py
@@ -668,6 +668,8 @@ def _poll_local_ms_for_oai_code_graph(ms_service, target_email: str, mailbox_dic
         if getattr(cfg, 'GLOBAL_STOP', False): return ""
 
         messages = ms_service.fetch_openai_messages(mailbox_dict)
+        if mailbox_dict.get("_polling_stopped") == "abuse_mode":
+            return ""
         if not messages:
             if attempt % 2 == 0:
                 print(f"[{cfg.ts()}] [INFO] 第 {attempt + 1} 次轮询: 未发现任何邮件", flush=True)


### PR DESCRIPTION
## Summary
- mark a Microsoft local mailbox as dead when the token refresh fallback returns `AADSTS70000` with `service abuse mode`
- prefer `master_email` when present so pool-fission aliases retire the real mailbox owner
- add a regression test that verifies the mailbox is marked `status=3`

## Testing
- python -m unittest tests.test_local_microsoft_service_abuse_mode