### PR TITLE
Repick HeroSMS countries after NO_NUMBERS

### DIFF
--- a/tests/test_hero_sms_country_retry.py
+++ b/tests/test_hero_sms_country_retry.py
@@ -1,0 +1,86 @@
+import io
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+fake_requests_module = types.SimpleNamespace(get=None, post=None, Session=object)
+sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
+sys.modules.setdefault(
+    "utils.db_manager",
+    types.SimpleNamespace(
+        get_sys_kv=lambda *args, **kwargs: None,
+        set_sys_kv=lambda *args, **kwargs: None,
+    ),
+)
+
+from utils.integrations.hero_sms import _try_verify_phone_via_hero_sms
+
+
+class _DummySession:
+    pass
+
+
+class HeroSmsCountryRetryTests(unittest.TestCase):
+    def test_no_numbers_retries_same_country_when_auto_pick_disabled(self):
+        attempted_countries = []
+
+        def fake_get_number(proxies, *, service_code="", country_id=None):
+            attempted_countries.append(int(country_id))
+            return "", "", "NO_NUMBERS"
+
+        with patch("utils.integrations.hero_sms._hero_sms_enabled", return_value=True), \
+                patch("utils.integrations.hero_sms._hero_sms_max_tries", return_value=2), \
+                patch("utils.integrations.hero_sms.hero_sms_get_balance", return_value=(9.92, "")), \
+                patch("utils.integrations.hero_sms._hero_sms_update_runtime"), \
+                patch("utils.integrations.hero_sms._hero_sms_resolve_service_code", return_value="dr"), \
+                patch("utils.integrations.hero_sms._hero_sms_resolve_country_id", return_value=16), \
+                patch("utils.integrations.hero_sms._hero_sms_auto_pick_country", return_value=False), \
+                patch("utils.integrations.hero_sms._hero_sms_pick_country_id", return_value=16) as pick_country_mock, \
+                patch("utils.integrations.hero_sms._hero_sms_reuse_enabled", return_value=False), \
+                patch("utils.integrations.hero_sms._hero_sms_get_number", side_effect=fake_get_number), \
+                patch("utils.integrations.hero_sms._sleep_interruptible", return_value=False):
+            with redirect_stdout(io.StringIO()):
+                ok, reason = _try_verify_phone_via_hero_sms(
+                    session=_DummySession(),
+                    proxies={"http": "http://proxy", "https": "http://proxy"},
+                )
+
+        self.assertFalse(ok)
+        self.assertEqual("取号失败: NO_NUMBERS", reason)
+        self.assertEqual([16, 16], attempted_countries)
+        pick_country_mock.assert_called_once()
+
+    def test_no_numbers_repicks_country_when_auto_pick_enabled(self):
+        attempted_countries = []
+
+        def fake_get_number(proxies, *, service_code="", country_id=None):
+            attempted_countries.append(int(country_id))
+            return "", "", "NO_NUMBERS"
+
+        with patch("utils.integrations.hero_sms._hero_sms_enabled", return_value=True), \
+                patch("utils.integrations.hero_sms._hero_sms_max_tries", return_value=2), \
+                patch("utils.integrations.hero_sms.hero_sms_get_balance", return_value=(9.92, "")), \
+                patch("utils.integrations.hero_sms._hero_sms_update_runtime"), \
+                patch("utils.integrations.hero_sms._hero_sms_resolve_service_code", return_value="dr"), \
+                patch("utils.integrations.hero_sms._hero_sms_resolve_country_id", return_value=16), \
+                patch("utils.integrations.hero_sms._hero_sms_auto_pick_country", return_value=True), \
+                patch("utils.integrations.hero_sms._hero_sms_pick_country_id", side_effect=[86, 91]) as pick_country_mock, \
+                patch("utils.integrations.hero_sms._hero_sms_reuse_enabled", return_value=False), \
+                patch("utils.integrations.hero_sms._hero_sms_get_number", side_effect=fake_get_number), \
+                patch("utils.integrations.hero_sms._sleep_interruptible", return_value=False):
+            with redirect_stdout(io.StringIO()):
+                ok, reason = _try_verify_phone_via_hero_sms(
+                    session=_DummySession(),
+                    proxies={"http": "http://proxy", "https": "http://proxy"},
+                )
+
+        self.assertFalse(ok)
+        self.assertEqual("取号失败: NO_NUMBERS", reason)
+        self.assertEqual([86, 91], attempted_countries)
+        self.assertEqual(2, pick_country_mock.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/integrations/hero_sms.py
+++ b/utils/integrations/hero_sms.py
@@ -391,7 +391,12 @@ def _get_country_names_map(proxies: Any) -> dict[int, str]:
     return _HERO_SMS_COUNTRY_NAMES_MAP
 
 
-def _hero_sms_prices_by_service(service_code: str, proxies: Any) -> list[dict[str, Any]]:
+def _hero_sms_prices_by_service(
+        service_code: str,
+        proxies: Any,
+        *,
+        force_refresh: bool = False,
+) -> list[dict[str, Any]]:
     svc = str(service_code or "").strip()
     # 自动转换：如果用户填的是 openai，底层自动查 dr
     search_svc = "dr" if svc.lower() == "openai" else svc
@@ -407,7 +412,7 @@ def _hero_sms_prices_by_service(service_code: str, proxies: Any) -> list[dict[st
         cache_svc = str(_HERO_SMS_PRICE_CACHE.get("service") or "")
         cache_at = float(_HERO_SMS_PRICE_CACHE.get("updated_at") or 0.0)
         cache_items = list(_HERO_SMS_PRICE_CACHE.get("items") or [])
-        if cache_svc == svc and cache_items and (now - cache_at) <= float(ttl):
+        if (not force_refresh) and cache_svc == svc and cache_items and (now - cache_at) <= float(ttl):
             return [dict(x) for x in cache_items if isinstance(x, dict)]
 
     # 2. 获取国家名称映射
@@ -496,8 +501,11 @@ def _hero_sms_pick_country_id(
         *,
         service_code: str,
         preferred_country: int,
+        exclude_country_ids: Optional[set[int]] = None,
+        force_refresh: bool = False,
 ) -> int:
     preferred = int(preferred_country)
+    excluded = {int(x) for x in (exclude_country_ids or set())}
     if not _hero_sms_auto_pick_country():
         if preferred in _OPENAI_SMS_BLOCKED_COUNTRY_IDS:
             _warn(f"HeroSMS 已关闭自动选国：首选国家 ID {preferred} 在黑名单内，仍将尝试使用该 ID")
@@ -506,7 +514,7 @@ def _hero_sms_pick_country_id(
             _warn(f"HeroSMS 已关闭自动选国：首选国家冷却中，仍使用 {preferred}")
         return preferred
 
-    rows = _hero_sms_prices_by_service(service_code, proxies)
+    rows = _hero_sms_prices_by_service(service_code, proxies, force_refresh=force_refresh)
     if not rows:
         if preferred not in _OPENAI_SMS_BLOCKED_COUNTRY_IDS and not _hero_sms_country_is_on_cooldown(preferred):
             return preferred
@@ -516,6 +524,8 @@ def _hero_sms_pick_country_id(
     for row in rows:
         cid = int(row.get("country") or -1)
         if cid < 0:
+            continue
+        if cid in excluded:
             continue
         try:
             cost = float(row.get("cost") or -1.0)
@@ -842,6 +852,13 @@ def _is_hero_sms_country_blocked_issue(reason: str) -> bool:
     if not low:
         return False
     return "country_blocked" in low or "国家受限" in low
+
+
+def _is_hero_sms_no_numbers_issue(reason: str) -> bool:
+    low = str(reason or "").strip().lower()
+    if not low:
+        return False
+    return "no_numbers" in low or "no numbers" in low or "no free phones" in low
 
 def _hero_sms_get_number(
         proxies: Any,
@@ -1171,6 +1188,7 @@ def _try_verify_phone_via_hero_sms(
             service_code=service_code,
             preferred_country=preferred_country_id,
         )
+        excluded_country_ids: set[int] = set()
         if country_id != preferred_country_id:
             _warn(
                 f"HeroSMS 国家自动切换: {preferred_country_id} -> {country_id}"
@@ -1242,6 +1260,25 @@ def _try_verify_phone_via_hero_sms(
                     break
                 if _is_hero_sms_country_blocked_issue(get_err):
                     break
+                if (
+                        attempt < max_tries
+                        and _hero_sms_auto_pick_country()
+                        and _is_hero_sms_no_numbers_issue(get_err)
+                ):
+                    excluded_country_ids.add(int(country_id))
+                    next_country = _hero_sms_pick_country_id(
+                        proxies,
+                        service_code=service_code,
+                        preferred_country=preferred_country_id,
+                        exclude_country_ids=excluded_country_ids,
+                        force_refresh=True,
+                    )
+                    if next_country != country_id:
+                        _warn(f"当前国家无号，自动重选国家: {country_id} -> {next_country}")
+                        country_id = next_country
+                        if _sleep_interruptible(0.3):
+                            raise UserStoppedError("stopped_by_user")
+                        continue
                 if _sleep_interruptible(1.2):
                     raise UserStoppedError("stopped_by_user")
                 continue


### PR DESCRIPTION
## Summary
- retry HeroSMS country selection when `NO_NUMBERS` is returned and smart country picking is enabled
- keep the legacy same-country retry behavior when smart country picking is disabled
- add regression coverage for both retry paths

## Why
When HeroSMS returns `NO_NUMBERS`, the current flow keeps retrying within the same attempt budget. If smart country selection is enabled, we can do better by excluding the exhausted country for the current run, refreshing inventory, and repicking another candidate immediately.

This keeps the old behavior unchanged for users who do not enable smart country selection.

## Test Plan
- python -m unittest tests.test_hero_sms_country_retry
- python -m unittest tests.test_local_microsoft_service_abuse_mode
- python -m unittest tests.test_mail_service_abuse_mode

## Note
This PR intentionally does not wire repeated `NO_NUMBERS` outcomes into the existing country timeout/cooldown state machine yet. That follow-up can be handled separately if maintainers want `NO_NUMBERS` to affect long-lived country scoring/cooldown behavior as well.