### PR TITLE
feat(local_microsoft): configurable alias suffix strategy

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -55,6 +55,9 @@ local_microsoft:
   master_email: ""
   client_id: ""
   refresh_token: ""
+  suffix_mode: "fixed"
+  suffix_len_min: 8
+  suffix_len_max: 8
   pool_fission: false
 
 # [模式 "freemail" 专属]

--- a/index.html
+++ b/index.html
@@ -911,10 +911,28 @@
                                         <input type="text" v-model="config.local_microsoft.client_id" class="w-full appearance-none bg-slate-50 border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 shadow-inner font-mono text-sm" placeholder="如果导入的账号自带clientid这里则空着，如果你不想填也可以空着">
                                     </div>
 
-                                    <div v-if="config.local_microsoft.enable_fission" class="space-y-4 pt-4 border-t-2 border-dashed border-slate-100 animate-fade-in">
+                                    <div v-if="config.local_microsoft.enable_fission || config.local_microsoft.pool_fission" class="space-y-4 pt-4 border-t-2 border-dashed border-slate-100 animate-fade-in">
                                         <div>
                                             <label class="block text-slate-700 text-xs font-extrabold mb-1.5 uppercase tracking-wider">裂变主邮箱账号</label>
                                             <input type="text" v-model="config.local_microsoft.master_email" class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 shadow-sm font-mono text-sm" placeholder="例如：example@outlook.com">
+                                        </div>
+                                        <div>
+                                            <label class="block text-slate-700 text-xs font-extrabold mb-1.5 uppercase tracking-wider">Alias 后缀生成模式</label>
+                                            <select v-model="config.local_microsoft.suffix_mode" class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 shadow-sm text-sm">
+                                                <option value="fixed">fixed: hex (使用 min)</option>
+                                                <option value="range">range: hex (min~max)</option>
+                                                <option value="mystic">mystic: name+noun+bday</option>
+                                            </select>
+                                        </div>
+                                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                            <div>
+                                                <label class="block text-slate-700 text-xs font-extrabold mb-1.5 uppercase tracking-wider">Alias 最小长度 (8~32)</label>
+                                                <input type="number" min="8" max="32" v-model.number="config.local_microsoft.suffix_len_min" class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 shadow-sm font-mono text-sm">
+                                            </div>
+                                            <div>
+                                                <label class="block text-slate-700 text-xs font-extrabold mb-1.5 uppercase tracking-wider">Alias 最大长度 (8~32)</label>
+                                                <input type="number" min="8" max="32" v-model.number="config.local_microsoft.suffix_len_max" class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 shadow-sm font-mono text-sm">
+                                            </div>
                                         </div>
                                         <div>
                                             <div class="flex justify-between items-end mb-1.5">

--- a/routers/api_routes.py
+++ b/routers/api_routes.py
@@ -311,20 +311,46 @@ async def restart_system(token: str = Depends(verify_token)):
     except Exception as e:
         return {"status": "error", "message": f"重启异常: {str(e)}"}
 
+def _sanitize_local_microsoft_config(local_ms: Any) -> dict:
+    data = dict(local_ms) if isinstance(local_ms, dict) else {}
+    data.setdefault("enable_fission", False)
+    data.setdefault("pool_fission", False)
+    data.setdefault("master_email", "")
+    data.setdefault("client_id", "")
+    data.setdefault("refresh_token", "")
+
+    mode = str(data.get("suffix_mode", "fixed") or "fixed").strip().lower()
+    if mode not in {"fixed", "range", "mystic"}:
+        mode = "fixed"
+
+    try:
+        min_len = int(data.get("suffix_len_min", 8) or 8)
+    except Exception:
+        min_len = 8
+    try:
+        max_len = int(data.get("suffix_len_max", min_len) or min_len)
+    except Exception:
+        max_len = min_len
+
+    min_len = max(8, min(32, min_len))
+    max_len = max(8, min(32, max_len))
+    if max_len < min_len:
+        max_len = min_len
+
+    data["suffix_mode"] = mode
+    data["suffix_len_min"] = min_len
+    data["suffix_len_max"] = max_len
+    return data
+
+
 @router.get("/api/config")
 async def get_config(token: str = Depends(verify_token)):
     config_data = getattr(core_engine.cfg, '_c', {}).copy()
 
     if isinstance(config_data.get("sub2api_mode"), dict):
         config_data["sub2api_mode"].pop("min_remaining_weekly_percent", None)
-    config_data["web_password"] = getattr(core_engine.cfg, "WEB_PASSWORD", "admin")
-    if "local_microsoft" not in config_data:
-        config_data["local_microsoft"] = {
-            "enable_fission": False,
-            "master_email": "",
-            "client_id": "",
-            "refresh_token": ""
-        }
+    config_data["web_password"] = getattr(core_engine.cfg, "WEB_PASSWORD", config_data.get("web_password", "admin"))
+    config_data["local_microsoft"] = _sanitize_local_microsoft_config(config_data.get("local_microsoft"))
     return config_data
 
 
@@ -333,6 +359,7 @@ async def save_config(new_config: dict, token: str = Depends(verify_token)):
     try:
         if isinstance(new_config.get("sub2api_mode"), dict):
             new_config["sub2api_mode"].pop("min_remaining_weekly_percent", None)
+        new_config["local_microsoft"] = _sanitize_local_microsoft_config(new_config.get("local_microsoft"))
         reload_all_configs(new_config_dict=new_config)
 
         return {"status": "success", "message": "✅ 配置已成功保存并同步至云端！"}
@@ -1199,7 +1226,6 @@ def parse_sub2api_proxy(proxy_url: str):
         return proxy_dict
     except:
         return None
-
 @router.post("/api/accounts/export_all")
 async def export_all_accounts(token: str = Depends(verify_token)):
     data = db_manager.get_all_accounts_raw()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -301,10 +301,26 @@ createApp({
                 if (!this.config.local_microsoft) {
                     this.config.local_microsoft = {
                         enable_fission: false,
+                        pool_fission: false,
                         master_email: '',
                         client_id: '',
-                        refresh_token: ''
+                        refresh_token: '',
+                        suffix_mode: 'fixed',
+                        suffix_len_min: 8,
+                        suffix_len_max: 8
                     };
+                }
+                if (this.config.local_microsoft.suffix_mode === undefined) {
+                    this.config.local_microsoft.suffix_mode = 'fixed';
+                }
+                if (this.config.local_microsoft.suffix_len_min === undefined) {
+                    this.config.local_microsoft.suffix_len_min = 8;
+                }
+                if (this.config.local_microsoft.suffix_len_max === undefined) {
+                    this.config.local_microsoft.suffix_len_max = 8;
+                }
+                if (this.config.local_microsoft.pool_fission === undefined) {
+                    this.config.local_microsoft.pool_fission = false;
                 }
                 if (this.config.sub2api_mode.test_model === undefined) {
                     this.config.sub2api_mode.test_model = 'gpt-5.2';
@@ -389,6 +405,20 @@ createApp({
                     this.config.clash_proxy_pool.blacklist = this.blacklistStr.split('\n').map(s => s.trim()).filter(s => s);
                     this.config.clash_proxy_pool.cluster_count = parseInt(this.clashPool.count) || 5;
                     this.config.clash_proxy_pool.sub_url = this.clashPool.subUrl;
+                }
+                if (this.config.local_microsoft) {
+                    const mode = String(this.config.local_microsoft.suffix_mode || 'fixed').toLowerCase();
+                    this.config.local_microsoft.suffix_mode = ['fixed', 'range', 'mystic'].includes(mode) ? mode : 'fixed';
+
+                    let minLen = parseInt(this.config.local_microsoft.suffix_len_min, 10);
+                    let maxLen = parseInt(this.config.local_microsoft.suffix_len_max, 10);
+                    if (Number.isNaN(minLen)) minLen = 8;
+                    if (Number.isNaN(maxLen)) maxLen = minLen;
+                    minLen = Math.max(8, Math.min(32, minLen));
+                    maxLen = Math.max(8, Math.min(32, maxLen));
+                    if (maxLen < minLen) maxLen = minLen;
+                    this.config.local_microsoft.suffix_len_min = minLen;
+                    this.config.local_microsoft.suffix_len_max = maxLen;
                 }
                 this.config.warp_proxy_list = this.warpListStr.split('\n').map(s => s.trim()).filter(s => s);
                 const res = await this.authFetch('/api/config', {

--- a/tests/test_local_microsoft_suffix.py
+++ b/tests/test_local_microsoft_suffix.py
@@ -1,0 +1,182 @@
+import sys
+import types
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+try:
+    import curl_cffi  # noqa: F401
+except Exception:
+    fake_requests_module = types.SimpleNamespace(post=None, get=None)
+    sys.modules["curl_cffi"] = types.SimpleNamespace(requests=fake_requests_module)
+
+from utils import config as cfg
+from utils.email_providers.local_microsoft_service import LocalMicrosoftService
+
+
+class LocalMicrosoftSuffixTests(unittest.TestCase):
+    def setUp(self):
+        self.service = LocalMicrosoftService()
+
+    def _patch_cfg(self, **kwargs):
+        defaults = {
+            "LOCAL_MS_SUFFIX_MODE": "fixed",
+            "LOCAL_MS_SUFFIX_LEN_MIN": 8,
+            "LOCAL_MS_SUFFIX_LEN_MAX": 8,
+            "LOCAL_MS_ENABLE_FISSION": False,
+            "LOCAL_MS_MASTER_EMAIL": "",
+            "LOCAL_MS_CLIENT_ID": "",
+            "LOCAL_MS_REFRESH_TOKEN": "",
+            "LOCAL_MS_POOL_FISSION": False,
+        }
+        defaults.update(kwargs)
+        stack = ExitStack()
+        for key, value in defaults.items():
+            stack.enter_context(patch.object(cfg, key, value))
+        return stack
+
+    def test_fixed_mode_uses_min_length_hex(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="fixed",
+            LOCAL_MS_SUFFIX_LEN_MIN=12,
+            LOCAL_MS_SUFFIX_LEN_MAX=24,
+        ):
+            suffix = self.service.generate_suffix_v2(user_part="alpha")
+        self.assertEqual(12, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_range_mode_uses_random_length_within_bounds(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="range",
+            LOCAL_MS_SUFFIX_LEN_MIN=8,
+            LOCAL_MS_SUFFIX_LEN_MAX=16,
+        ):
+            with patch("utils.email_providers.local_microsoft_service.random.randint", return_value=15):
+                suffix = self.service.generate_suffix_v2(user_part="alpha")
+        self.assertEqual(15, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_mystic_mode_is_alnum_and_respects_target_length(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="mystic",
+            LOCAL_MS_SUFFIX_LEN_MIN=20,
+            LOCAL_MS_SUFFIX_LEN_MAX=20,
+        ):
+            suffix = self.service.generate_suffix_v2(user_part="alpha")
+        self.assertEqual(20, len(suffix))
+        self.assertRegex(suffix, r"^[a-z0-9]+$")
+
+    def test_invalid_mode_falls_back_to_fixed_mode(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="invalid-mode",
+            LOCAL_MS_SUFFIX_LEN_MIN=11,
+            LOCAL_MS_SUFFIX_LEN_MAX=22,
+        ):
+            suffix = self.service.generate_suffix_v2(user_part="alpha")
+        self.assertEqual(11, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_suffix_bounds_normalize_when_max_less_than_min(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="range",
+            LOCAL_MS_SUFFIX_LEN_MIN=20,
+            LOCAL_MS_SUFFIX_LEN_MAX=8,
+        ):
+            suffix = self.service.generate_suffix_v2(user_part="alpha")
+        self.assertEqual(20, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_suffix_returns_empty_when_local_part_has_no_room(self):
+        with self._patch_cfg(
+            LOCAL_MS_SUFFIX_MODE="range",
+            LOCAL_MS_SUFFIX_LEN_MIN=8,
+            LOCAL_MS_SUFFIX_LEN_MAX=32,
+        ):
+            suffix = self.service.generate_suffix_v2(user_part=("a" * 63))
+        self.assertEqual("", suffix)
+
+    def test_manual_fission_uses_configured_suffix_mode(self):
+        with self._patch_cfg(
+            LOCAL_MS_ENABLE_FISSION=True,
+            LOCAL_MS_MASTER_EMAIL="seed@outlook.com",
+            LOCAL_MS_CLIENT_ID="client",
+            LOCAL_MS_REFRESH_TOKEN="rt",
+            LOCAL_MS_SUFFIX_MODE="fixed",
+            LOCAL_MS_SUFFIX_LEN_MIN=10,
+            LOCAL_MS_SUFFIX_LEN_MAX=10,
+        ):
+            mailbox = self.service.get_unused_mailbox()
+        self.assertIsNotNone(mailbox)
+        self.assertIn("+", mailbox["email"])
+        local_part = mailbox["email"].split("@")[0]
+        suffix = local_part.split("+", 1)[1]
+        self.assertEqual(10, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_manual_fission_falls_back_to_master_when_suffix_cannot_fit(self):
+        master_email = ("a" * 63) + "@outlook.com"
+        with self._patch_cfg(
+            LOCAL_MS_ENABLE_FISSION=True,
+            LOCAL_MS_MASTER_EMAIL=master_email,
+            LOCAL_MS_CLIENT_ID="client",
+            LOCAL_MS_REFRESH_TOKEN="rt",
+            LOCAL_MS_SUFFIX_MODE="range",
+            LOCAL_MS_SUFFIX_LEN_MIN=8,
+            LOCAL_MS_SUFFIX_LEN_MAX=32,
+        ):
+            mailbox = self.service.get_unused_mailbox()
+        self.assertIsNotNone(mailbox)
+        self.assertEqual(master_email, mailbox["email"])
+
+    def test_pool_fission_uses_configured_suffix_mode(self):
+        pool_mailbox = {
+            "id": 100,
+            "email": "seed@outlook.com",
+            "retry_master": 0,
+            "client_id": "pool-client",
+            "refresh_token": "pool-rt",
+        }
+        with self._patch_cfg(
+            LOCAL_MS_POOL_FISSION=True,
+            LOCAL_MS_SUFFIX_MODE="fixed",
+            LOCAL_MS_SUFFIX_LEN_MIN=9,
+            LOCAL_MS_SUFFIX_LEN_MAX=9,
+        ):
+            with patch(
+                "utils.email_providers.local_microsoft_service.db_manager.get_mailbox_for_pool_fission",
+                return_value=pool_mailbox,
+            ):
+                mailbox = self.service.get_unused_mailbox()
+        self.assertIsNotNone(mailbox)
+        self.assertIn("+", mailbox["email"])
+        local_part = mailbox["email"].split("@")[0]
+        suffix = local_part.split("+", 1)[1]
+        self.assertEqual(9, len(suffix))
+        self.assertRegex(suffix, r"^[0-9a-f]+$")
+
+    def test_pool_fission_falls_back_to_master_when_suffix_cannot_fit(self):
+        master_email = ("a" * 63) + "@outlook.com"
+        pool_mailbox = {
+            "id": 101,
+            "email": master_email,
+            "retry_master": 0,
+            "client_id": "pool-client",
+            "refresh_token": "pool-rt",
+        }
+        with self._patch_cfg(
+            LOCAL_MS_POOL_FISSION=True,
+            LOCAL_MS_SUFFIX_MODE="range",
+            LOCAL_MS_SUFFIX_LEN_MIN=8,
+            LOCAL_MS_SUFFIX_LEN_MAX=32,
+        ):
+            with patch(
+                "utils.email_providers.local_microsoft_service.db_manager.get_mailbox_for_pool_fission",
+                return_value=pool_mailbox,
+            ):
+                mailbox = self.service.get_unused_mailbox()
+        self.assertIsNotNone(mailbox)
+        self.assertEqual(master_email, mailbox["email"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -98,6 +98,9 @@ LOCAL_MS_MASTER_EMAIL: str = ""
 LOCAL_MS_PASSWORD: str = ""
 LOCAL_MS_CLIENT_ID: str = ""
 LOCAL_MS_REFRESH_TOKEN: str = ""
+LOCAL_MS_SUFFIX_MODE: str = "fixed"
+LOCAL_MS_SUFFIX_LEN_MIN: int = 8
+LOCAL_MS_SUFFIX_LEN_MAX: int = 8
 FREEMAIL_API_URL: str = ""
 FREEMAIL_API_TOKEN: str = ""
 CM_API_URL: str = ""
@@ -243,6 +246,7 @@ def reload_all_configs(new_config_dict=None):
     global CLUSTER_NODE_NAME, CLUSTER_MASTER_URL, CLUSTER_SECRET
     global REG_MODE
     global LOCAL_MS_ENABLE_FISSION, LOCAL_MS_MASTER_EMAIL, LOCAL_MS_PASSWORD, LOCAL_MS_CLIENT_ID, LOCAL_MS_REFRESH_TOKEN, LOCAL_MS_POOL_FISSION
+    global LOCAL_MS_SUFFIX_MODE, LOCAL_MS_SUFFIX_LEN_MIN, LOCAL_MS_SUFFIX_LEN_MAX
     global DB_TYPE, MYSQL_CFG
     global MAX_LOG_LINES
 
@@ -359,6 +363,21 @@ def reload_all_configs(new_config_dict=None):
     LOCAL_MS_MASTER_EMAIL = str(_local_microsoft.get("master_email", "")).strip()
     LOCAL_MS_CLIENT_ID = str(_local_microsoft.get("client_id", "")).strip()
     LOCAL_MS_REFRESH_TOKEN = str(_local_microsoft.get("refresh_token", "")).strip()
+    LOCAL_MS_SUFFIX_MODE = str(_local_microsoft.get("suffix_mode", "fixed")).strip().lower()
+    if LOCAL_MS_SUFFIX_MODE not in {"fixed", "range", "mystic"}:
+        LOCAL_MS_SUFFIX_MODE = "fixed"
+    try:
+        LOCAL_MS_SUFFIX_LEN_MIN = int(_local_microsoft.get("suffix_len_min", 8) or 8)
+    except Exception:
+        LOCAL_MS_SUFFIX_LEN_MIN = 8
+    try:
+        LOCAL_MS_SUFFIX_LEN_MAX = int(_local_microsoft.get("suffix_len_max", LOCAL_MS_SUFFIX_LEN_MIN) or LOCAL_MS_SUFFIX_LEN_MIN)
+    except Exception:
+        LOCAL_MS_SUFFIX_LEN_MAX = LOCAL_MS_SUFFIX_LEN_MIN
+    LOCAL_MS_SUFFIX_LEN_MIN = max(8, min(32, LOCAL_MS_SUFFIX_LEN_MIN))
+    LOCAL_MS_SUFFIX_LEN_MAX = max(8, min(32, LOCAL_MS_SUFFIX_LEN_MAX))
+    if LOCAL_MS_SUFFIX_LEN_MAX < LOCAL_MS_SUFFIX_LEN_MIN:
+        LOCAL_MS_SUFFIX_LEN_MAX = LOCAL_MS_SUFFIX_LEN_MIN
 
     _free = _c.get("freemail", {})
     FREEMAIL_API_URL = str(_free.get("api_url", "")).strip().rstrip("/")

--- a/utils/email_providers/local_microsoft_service.py
+++ b/utils/email_providers/local_microsoft_service.py
@@ -2,7 +2,6 @@ import json
 import random
 import string
 import time
-import uuid
 import threading
 import imaplib
 import base64
@@ -22,24 +21,90 @@ class MailboxAbuseModeError(RuntimeError):
 
 
 class LocalMicrosoftService:
+    _MYSTIC_NAMES = [
+        "leo", "nova", "kai", "luna", "milo", "iris", "axel", "zara"
+    ]
+    _MYSTIC_NOUNS = [
+        "fox", "river", "comet", "lotus", "cloud", "ember", "aurora", "tiger"
+    ]
+
     def __init__(self, proxies: Optional[Dict[str, str]] = None):
         self.proxies = proxies
         self.token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
         self.graph_base_url = "https://graph.microsoft.com/v1.0/me"
 
-    def generate_suffix_v2(self):
-        return uuid.uuid4().hex[:8]
+    def _resolve_suffix_mode(self) -> str:
+        mode = str(getattr(cfg, "LOCAL_MS_SUFFIX_MODE", "fixed") or "fixed").strip().lower()
+        if mode not in {"fixed", "range", "mystic"}:
+            return "fixed"
+        return mode
+
+    def _resolve_suffix_bounds(self, user_part: str) -> tuple[int, int]:
+        try:
+            min_len = int(getattr(cfg, "LOCAL_MS_SUFFIX_LEN_MIN", 8) or 8)
+        except Exception:
+            min_len = 8
+        try:
+            max_len = int(getattr(cfg, "LOCAL_MS_SUFFIX_LEN_MAX", min_len) or min_len)
+        except Exception:
+            max_len = min_len
+
+        min_len = max(8, min(32, min_len))
+        max_len = max(8, min(32, max_len))
+        if max_len < min_len:
+            max_len = min_len
+
+        # RFC local-part max length is 64, include plus separator itself.
+        user_len = len(str(user_part or ""))
+        available = 64 - user_len - 1
+        if available <= 0:
+            return 0, 0
+
+        min_len = max(1, min(min_len, available))
+        max_len = max(min_len, min(max_len, available))
+        return min_len, max_len
+
+    def _random_hex(self, length: int) -> str:
+        return "".join(random.choices("0123456789abcdef", k=max(1, int(length))))
+
+    def _build_mystic_seed(self) -> str:
+        name = random.choice(self._MYSTIC_NAMES)
+        noun = random.choice(self._MYSTIC_NOUNS)
+        mmdd = f"{random.randint(1, 12):02d}{random.randint(1, 28):02d}"
+        yyyy = str(random.randint(1990, 2012))
+        return random.choice([
+            f"{name}{noun}{mmdd}",
+            f"{noun}{name}{mmdd}",
+            f"{name}{mmdd}{noun}",
+            f"{name}{noun}{yyyy}",
+        ]).lower()
+
+    def generate_suffix_v2(self, user_part: str = ""):
+        mode = self._resolve_suffix_mode()
+        min_len, max_len = self._resolve_suffix_bounds(user_part)
+        if max_len <= 0:
+            return ""
+        target_len = min_len if mode == "fixed" else random.randint(min_len, max_len)
+
+        if mode == "mystic":
+            suffix = "".join(ch for ch in self._build_mystic_seed() if ch.isalnum())
+            if len(suffix) < target_len:
+                suffix += "".join(random.choices(string.ascii_lowercase + string.digits, k=target_len - len(suffix)))
+            return suffix[:target_len]
+
+        return self._random_hex(target_len)
 
     def get_unused_mailbox(self) -> Optional[dict]:
         """核心逻辑"""
         if getattr(cfg, "LOCAL_MS_ENABLE_FISSION", False):
             master_email = getattr(cfg, "LOCAL_MS_MASTER_EMAIL", "").strip()
             if master_email and "@" in master_email:
-                random_suffix = self.generate_suffix_v2()
                 user_part, domain_part = master_email.split("@", 1)
+                random_suffix = self.generate_suffix_v2(user_part=user_part)
+                target_email = f"{user_part}+{random_suffix}@{domain_part}" if random_suffix else master_email
                 return {
                     "id": "manual_config",
-                    "email": f"{user_part}+{random_suffix}@{domain_part}",
+                    "email": target_email,
                     "master_email": master_email,
                     "is_raw_trial": False,
                     "client_id": getattr(cfg, "LOCAL_MS_CLIENT_ID", ""),
@@ -58,9 +123,9 @@ class LocalMicrosoftService:
                         target_email = master_email
                         db_manager.clear_retry_master_status(master_email)
                     else:
-                        random_suffix = self.generate_suffix_v2()
                         user_part, domain_part = master_email.split("@", 1)
-                        target_email = f"{user_part}+{random_suffix}@{domain_part}"
+                        random_suffix = self.generate_suffix_v2(user_part=user_part)
+                        target_email = f"{user_part}+{random_suffix}@{domain_part}" if random_suffix else master_email
 
                     return {
                         "id": mailbox_data["id"],


### PR DESCRIPTION
﻿## Summary
- add configurable local Microsoft alias suffix strategy (`fixed` / `range` / `mystic`)
- add suffix length bounds (`8~32`) and normalize invalid values in backend + frontend
- enforce local-part length safety by falling back to the master email when `+suffix` cannot fit
- make suffix configuration visible for both manual fission and pool fission
- add unit tests for mode fallback, bounds normalization, long local-part fallback, and pool-fission behavior

## Fixes Included
- sanitize `local_microsoft` in `/api/config` read/write so runtime state and readback stay consistent
- avoid generating overlong aliases when the mailbox local-part is near the RFC 64-character limit

## Tests
- `python -m unittest tests.test_local_microsoft_suffix tests.test_local_microsoft_service_abuse_mode`
