### PR TITLE
feat: add independent batch proxy pool

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -162,6 +162,23 @@ clash_proxy_pool:
     - "China"
     - "回国"
 
+raw_proxy_pool:
+  # 独立于 Clash 的批量代理池；启用后优先使用这里的代理列表
+  # 支持 HTTP / HTTPS / SOCKS5 显式协议；未写协议时默认按 socks5h 解析
+  enable: false
+  proxy_list:
+    # 支持以下格式：
+    # - http://user:pass@host:8080
+    # - https://user:pass@host:8443
+    # - socks5://user:pass@host:1080
+    # - socks5h://user:pass@host:1080
+    # - host:port
+    # - host:port:user:pass
+    # - user:pass@host:port
+    - "http://user:pass@127.0.0.1:8080"
+    - "socks5://user:pass@127.0.0.1:1080"
+    - "127.0.0.1:1081:user:pass"
+
 warp_proxy_list:
   - "http://127.0.0.1:41001"
   - "http://127.0.0.1:41002"

--- a/index.html
+++ b/index.html
@@ -1644,6 +1644,32 @@
                                 </div>
                             </div>
 
+                            <div class="bg-white p-6 md:p-8 rounded-2xl shadow-sm hover:shadow-md transition-shadow duration-300 border border-slate-200/60 border-l-4 border-l-cyan-500 bg-gradient-to-br from-cyan-50/40 to-white" v-if="config.raw_proxy_pool">
+                                <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 border-b border-cyan-100 pb-5 gap-4">
+                                    <div>
+                                        <h3 class="text-xl md:text-2xl font-black text-cyan-700 tracking-tight flex items-center gap-2"><span>🧦</span> 批量代理池</h3>
+                                        <p class="text-xs text-cyan-700/80 mt-2 font-medium">独立于 Clash 池，按列表轮换代理；启用后优先于 `warp_proxy_list`。</p>
+                                    </div>
+                                    <label class="relative inline-flex bg-white px-4 py-2.5 md:px-5 md:py-3 rounded-xl cursor-pointer hover:bg-cyan-50 transition-colors shadow-sm border border-cyan-200 w-full sm:w-auto items-center justify-center group">
+                                        <input type="checkbox" v-model="config.raw_proxy_pool.enable" class="sr-only peer">
+                                        <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-cyan-600 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
+                                        <span class="font-black text-cyan-900 text-sm md:text-base ml-3 tracking-wide">启用批量代理池</span>
+                                    </label>
+                                </div>
+                                <div class="space-y-4" :class="{'opacity-50 pointer-events-none grayscale-[50%] transition-opacity duration-300': !config.raw_proxy_pool.enable}">
+                                    <div class="bg-cyan-50/70 border border-cyan-200 rounded-2xl p-5 shadow-sm">
+                                        <label class="block text-cyan-800 text-xs font-black mb-2 flex items-center justify-between uppercase tracking-wider">
+                                            代理列表
+                                            <span class="text-[10px] font-bold text-cyan-500 bg-white px-2 py-0.5 rounded shadow-sm border border-cyan-100">一行一个</span>
+                                        </label>
+                                        <p class="text-xs text-cyan-700/80 mb-3 leading-relaxed">
+                                            支持 `http://...`、`https://...`、`socks5://...`、`socks5h://...`；未写协议时默认按 `socks5h://` 解析
+                                        </p>
+                                        <textarea v-model="rawProxyListStr" class="w-full appearance-none bg-white border border-cyan-200 text-cyan-900 rounded-xl py-3 px-4 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 focus:border-cyan-500 transition-colors shadow-inner h-[160px] font-mono text-xs leading-relaxed placeholder:text-cyan-300" placeholder="http://user:pass@1.2.3.4:8080&#10;socks5://user:pass@1.2.3.5:1080&#10;1.2.3.6:1080:user:pass"></textarea>
+                                    </div>
+                                </div>
+                            </div>
+
                             <div id="proxy-intelligence-pool" class="bg-white p-6 md:p-8 rounded-2xl shadow-sm hover:shadow-md transition-shadow duration-300 border border-slate-200/60 border-l-4 border-l-indigo-500 bg-gradient-to-br from-indigo-50/30 to-white" v-if="config.clash_proxy_pool">
                                 <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 md:mb-8 border-b border-indigo-100 pb-5 gap-4">
                                     <h3 class="text-xl md:text-2xl font-black text-indigo-700 tracking-tight flex items-center gap-2"><span>🌍</span> Clash 节点智能池</h3>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,24 @@
 const { createApp } = Vue;
 
+function normalizeBooleanLike(value, defaultValue = false) {
+    if (value === true || value === false) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+            return true;
+        }
+        if (['0', 'false', 'no', 'off', ''].includes(normalized)) {
+            return false;
+        }
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    return defaultValue;
+}
+
 createApp({
     data() {
         return {
@@ -54,6 +73,7 @@ createApp({
             config: null,
             blacklistStr: "",
             warpListStr: "",
+            rawProxyListStr: "",
             accounts: [],
             selectedAccounts: [],
 			currentPage: 1,
@@ -384,6 +404,8 @@ createApp({
                 }
                 if(this.config.clash_proxy_pool && Array.isArray(this.config.clash_proxy_pool.blacklist)) {
                     this.blacklistStr = this.config.clash_proxy_pool.blacklist.join('\n');
+                } else {
+                    this.blacklistStr = '';
                 }
                 if (this.config.clash_proxy_pool.cluster_count !== undefined) {
                     this.clashPool.count = parseInt(this.config.clash_proxy_pool.cluster_count) || 5;
@@ -391,9 +413,21 @@ createApp({
                 if (this.config.clash_proxy_pool.sub_url !== undefined) {
                     this.clashPool.subUrl = this.config.clash_proxy_pool.sub_url;
                 }
+                if (!this.config.raw_proxy_pool || typeof this.config.raw_proxy_pool !== 'object' || Array.isArray(this.config.raw_proxy_pool)) {
+                    this.config.raw_proxy_pool = { enable: false, proxy_list: [] };
+                } else {
+                    this.config.raw_proxy_pool.enable = normalizeBooleanLike(this.config.raw_proxy_pool.enable, false);
+                    if (!Array.isArray(this.config.raw_proxy_pool.proxy_list)) {
+                        this.config.raw_proxy_pool.proxy_list = [];
+                    }
+                }
                 if(Array.isArray(this.config.warp_proxy_list)) {
                     this.warpListStr = this.config.warp_proxy_list.join('\n');
+                } else {
+                    this.config.warp_proxy_list = [];
+                    this.warpListStr = '';
                 }
+                this.rawProxyListStr = this.config.raw_proxy_pool.proxy_list.join('\n');
                 if (this.config.cluster_node_name === undefined) this.config.cluster_node_name = '';
                 if (this.config.cluster_master_url === undefined) this.config.cluster_master_url = '';
                 if (this.config.cluster_secret === undefined) this.config.cluster_secret = 'wenfxl666';
@@ -421,6 +455,11 @@ createApp({
                     this.config.local_microsoft.suffix_len_max = maxLen;
                 }
                 this.config.warp_proxy_list = this.warpListStr.split('\n').map(s => s.trim()).filter(s => s);
+                if (!this.config.raw_proxy_pool || typeof this.config.raw_proxy_pool !== 'object' || Array.isArray(this.config.raw_proxy_pool)) {
+                    this.config.raw_proxy_pool = { enable: false, proxy_list: [] };
+                }
+                this.config.raw_proxy_pool.enable = normalizeBooleanLike(this.config.raw_proxy_pool.enable, false);
+                this.config.raw_proxy_pool.proxy_list = this.rawProxyListStr.split('\n').map(s => s.trim()).filter(s => s);
                 const res = await this.authFetch('/api/config', {
                     method: 'POST', body: JSON.stringify(this.config)
                 });

--- a/tests/test_raw_proxy_pool.py
+++ b/tests/test_raw_proxy_pool.py
@@ -1,0 +1,212 @@
+import unittest
+from unittest.mock import patch
+
+import utils.config as cfg
+
+
+class RawProxyPoolTests(unittest.TestCase):
+    def _queue_values(self):
+        return [cfg.unpack_proxy_queue_item(item)[1] for item in list(cfg.PROXY_QUEUE.queue)]
+
+    def setUp(self):
+        self._original_queue = list(cfg.PROXY_QUEUE.queue)
+        self._original_unfinished_tasks = cfg.PROXY_QUEUE.unfinished_tasks
+        self._original_queue_generation = cfg.PROXY_QUEUE_GENERATION
+        self._original_raw_enable = getattr(cfg, "_raw_proxy_enable", False)
+        self._original_raw_list = list(getattr(cfg, "RAW_PROXY_LIST", []))
+        self._original_clash_enable = cfg._clash_enable
+        self._original_clash_pool_mode = cfg._clash_pool_mode
+        self._original_warp_list = list(cfg.WARP_PROXY_LIST)
+        with cfg.PROXY_QUEUE.mutex:
+            cfg.PROXY_QUEUE.queue.clear()
+            cfg.PROXY_QUEUE.unfinished_tasks = 0
+            cfg.PROXY_QUEUE.all_tasks_done.notify_all()
+
+    def tearDown(self):
+        cfg._raw_proxy_enable = self._original_raw_enable
+        cfg.RAW_PROXY_LIST = self._original_raw_list
+        cfg._clash_enable = self._original_clash_enable
+        cfg._clash_pool_mode = self._original_clash_pool_mode
+        cfg.WARP_PROXY_LIST = self._original_warp_list
+        cfg.PROXY_QUEUE_GENERATION = self._original_queue_generation
+        with cfg.PROXY_QUEUE.mutex:
+            cfg.PROXY_QUEUE.queue.clear()
+            cfg.PROXY_QUEUE.unfinished_tasks = self._original_unfinished_tasks
+            for item in self._original_queue:
+                cfg.PROXY_QUEUE.queue.append(item)
+            if cfg.PROXY_QUEUE.unfinished_tasks == 0:
+                cfg.PROXY_QUEUE.all_tasks_done.notify_all()
+
+    def test_normalize_raw_proxy_entry_accepts_standard_socks_url(self):
+        self.assertEqual(
+            "socks5h://user:pass@127.0.0.1:1080",
+            cfg.normalize_raw_proxy_entry("socks5://user:pass@127.0.0.1:1080"),
+        )
+
+    def test_normalize_raw_proxy_entry_accepts_http_url(self):
+        self.assertEqual(
+            "http://user:pass@127.0.0.1:8080",
+            cfg.normalize_raw_proxy_entry("http://user:pass@127.0.0.1:8080"),
+        )
+
+    def test_normalize_raw_proxy_entry_preserves_pre_encoded_credentials(self):
+        self.assertEqual(
+            "socks5h://user:p%40ss@127.0.0.1:1080",
+            cfg.normalize_raw_proxy_entry("socks5://user:p%40ss@127.0.0.1:1080"),
+        )
+
+    def test_normalize_raw_proxy_entry_accepts_colon_separated_auth_format(self):
+        self.assertEqual(
+            "socks5h://user:pass@127.0.0.1:1080",
+            cfg.normalize_raw_proxy_entry("127.0.0.1:1080:user:pass"),
+        )
+
+    def test_normalize_raw_proxy_entry_defaults_host_port_to_socks5h(self):
+        self.assertEqual(
+            "socks5h://127.0.0.1:1080",
+            cfg.normalize_raw_proxy_entry("127.0.0.1:1080"),
+        )
+
+    def test_reload_all_configs_prefers_raw_pool_over_clash_pool(self):
+        fake_config = {
+            "default_proxy": "http://default:8000",
+            "clash_proxy_pool": {
+                "enable": True,
+                "pool_mode": True,
+            },
+            "warp_proxy_list": [
+                "http://127.0.0.1:41001",
+                "http://127.0.0.1:41002",
+            ],
+            "raw_proxy_pool": {
+                "enable": True,
+                "proxy_list": [
+                    "http://user:pass@127.0.0.1:8080",
+                    "socks5://other:pwd@127.0.0.2:1081",
+                ],
+            },
+        }
+
+        with patch("utils.config.init_config", return_value=fake_config), patch(
+            "utils.config.reload_proxy_config"
+        ):
+            cfg.reload_all_configs()
+
+        self.assertTrue(cfg.is_raw_proxy_pool_enabled())
+        self.assertFalse(cfg.is_clash_proxy_pool_enabled())
+        self.assertTrue(cfg.is_queue_proxy_pool_enabled())
+        self.assertFalse(cfg.pooled_proxy_requires_clash_switch())
+        self.assertFalse(cfg.is_shared_clash_switch_enabled())
+        self.assertFalse(cfg._clash_enable)
+        self.assertEqual(
+            [
+                "http://user:pass@127.0.0.1:8080",
+                "socks5h://other:pwd@127.0.0.2:1081",
+            ],
+            self._queue_values(),
+        )
+
+    def test_reload_all_configs_resets_queue_generation_and_unfinished_tasks(self):
+        fake_config = {
+            "default_proxy": "http://default:8000",
+            "raw_proxy_pool": {
+                "enable": True,
+                "proxy_list": [
+                    "127.0.0.1:1080:user:pass",
+                    "127.0.0.2:1081:user:pass",
+                ],
+            },
+        }
+
+        with patch("utils.config.init_config", return_value=fake_config), patch(
+            "utils.config.reload_proxy_config"
+        ):
+            cfg.reload_all_configs()
+            first_generation = cfg.PROXY_QUEUE_GENERATION
+            self.assertEqual(2, cfg.PROXY_QUEUE.unfinished_tasks)
+            cfg.reload_all_configs()
+
+        self.assertEqual(first_generation + 1, cfg.PROXY_QUEUE_GENERATION)
+        self.assertEqual(2, cfg.PROXY_QUEUE.unfinished_tasks)
+        self.assertEqual(
+            [
+                "socks5h://user:pass@127.0.0.1:1080",
+                "socks5h://user:pass@127.0.0.2:1081",
+            ],
+            self._queue_values(),
+        )
+
+    def test_pooled_proxy_slot_drops_stale_proxy_after_reload(self):
+        old_config = {
+            "default_proxy": "http://default:8000",
+            "raw_proxy_pool": {
+                "enable": True,
+                "proxy_list": [
+                    "127.0.0.1:1080:user:pass",
+                ],
+            },
+        }
+        new_config = {
+            "default_proxy": "http://default:8000",
+            "raw_proxy_pool": {
+                "enable": True,
+                "proxy_list": [
+                    "127.0.0.9:1090:user:pass",
+                ],
+            },
+        }
+
+        with patch("utils.config.init_config", return_value=old_config), patch(
+            "utils.config.reload_proxy_config"
+        ):
+            cfg.reload_all_configs()
+
+        borrowed_generation, proxy = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+        self.assertEqual("socks5h://user:pass@127.0.0.1:1080", proxy)
+
+        with patch("utils.config.init_config", return_value=new_config), patch(
+            "utils.config.reload_proxy_config"
+        ):
+            cfg.reload_all_configs()
+
+        if cfg.should_return_pooled_proxy(borrowed_generation):
+            cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(proxy, borrowed_generation))
+            cfg.PROXY_QUEUE.task_done()
+
+        self.assertEqual(
+            ["socks5h://user:pass@127.0.0.9:1090"],
+            self._queue_values(),
+        )
+        self.assertEqual(1, cfg.PROXY_QUEUE.unfinished_tasks)
+
+    def test_dequeued_proxy_carries_current_generation_after_reload(self):
+        fake_config = {
+            "default_proxy": "http://default:8000",
+            "raw_proxy_pool": {
+                "enable": True,
+                "proxy_list": [
+                    "127.0.0.9:1090:user:pass",
+                ],
+            },
+        }
+
+        with patch("utils.config.init_config", return_value=fake_config), patch(
+            "utils.config.reload_proxy_config"
+        ):
+            cfg.reload_all_configs()
+
+        borrowed_generation, proxy = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+        self.assertEqual(cfg.PROXY_QUEUE_GENERATION, borrowed_generation)
+        self.assertTrue(cfg.should_return_pooled_proxy(borrowed_generation))
+        cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(proxy, borrowed_generation))
+        cfg.PROXY_QUEUE.task_done()
+
+        self.assertEqual(
+            ["socks5h://user:pass@127.0.0.9:1090"],
+            self._queue_values(),
+        )
+        self.assertEqual(1, cfg.PROXY_QUEUE.unfinished_tasks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -5,6 +5,7 @@ import yaml
 import random
 import string
 import shutil
+import urllib.parse
 from datetime import datetime
 from typing import Optional
 from utils.proxy_manager import reload_proxy_config
@@ -26,6 +27,102 @@ def format_docker_url(url: str) -> str:
         url = url.replace("127.0.0.1", "host.docker.internal")
         url = url.replace("localhost", "host.docker.internal")
     return url
+
+
+def normalize_raw_proxy_entry(entry: str) -> str:
+    value = str(entry or "").strip()
+    if not value or value.startswith("#"):
+        return ""
+
+    if "://" in value:
+        parsed = urllib.parse.urlparse(value)
+        scheme = (parsed.scheme or "").lower()
+        if scheme == "socks5":
+            scheme = "socks5h"
+        if scheme not in {"http", "https", "socks5h"}:
+            return ""
+        if not parsed.hostname:
+            return ""
+
+        if parsed.username is not None:
+            auth = urllib.parse.quote(urllib.parse.unquote(parsed.username), safe="")
+            if parsed.password is not None:
+                auth += ":" + urllib.parse.quote(urllib.parse.unquote(parsed.password), safe="")
+            auth += "@"
+        else:
+            auth = ""
+
+        default_port = 1080 if scheme == "socks5h" else 8080
+        return format_docker_url(f"{scheme}://{auth}{parsed.hostname}:{parsed.port or default_port}")
+
+    if "@" in value:
+        return normalize_raw_proxy_entry(f"socks5h://{value}")
+
+    parts = value.split(":")
+    if len(parts) == 2:
+        host, port = parts
+        host = host.strip()
+        port = port.strip()
+        if host and port:
+            return format_docker_url(f"socks5h://{host}:{port}")
+        return ""
+
+    if len(parts) >= 4:
+        host = parts[0].strip()
+        port = parts[1].strip()
+        username = parts[2].strip()
+        password = ":".join(parts[3:]).strip()
+        if host and port and username:
+            auth = urllib.parse.quote(urllib.parse.unquote(username), safe="")
+            if password:
+                auth += ":" + urllib.parse.quote(urllib.parse.unquote(password), safe="")
+            return format_docker_url(f"socks5h://{auth}@{host}:{port}")
+    return ""
+
+
+def normalize_raw_proxy_list(entries) -> list:
+    normalized = []
+    seen = set()
+    for entry in entries or []:
+        proxy = normalize_raw_proxy_entry(entry)
+        if proxy and proxy not in seen:
+            normalized.append(proxy)
+            seen.add(proxy)
+    return normalized
+
+
+def is_raw_proxy_pool_enabled() -> bool:
+    return _raw_proxy_enable and bool(RAW_PROXY_LIST)
+
+
+def is_clash_proxy_pool_enabled() -> bool:
+    return (not is_raw_proxy_pool_enabled()) and _clash_enable and _clash_pool_mode and bool(WARP_PROXY_LIST)
+
+
+def is_queue_proxy_pool_enabled() -> bool:
+    return is_raw_proxy_pool_enabled() or is_clash_proxy_pool_enabled()
+
+
+def pooled_proxy_requires_clash_switch() -> bool:
+    return is_clash_proxy_pool_enabled()
+
+
+def is_shared_clash_switch_enabled() -> bool:
+    return (not is_queue_proxy_pool_enabled()) and _clash_enable and not _clash_pool_mode
+
+
+def should_return_pooled_proxy(borrowed_generation: int) -> bool:
+    return borrowed_generation == PROXY_QUEUE_GENERATION
+
+
+def make_proxy_queue_item(proxy: str, generation: Optional[int] = None):
+    return (PROXY_QUEUE_GENERATION if generation is None else generation, proxy)
+
+
+def unpack_proxy_queue_item(item):
+    if isinstance(item, tuple) and len(item) == 2:
+        return item
+    return PROXY_QUEUE_GENERATION, item
 
 
 def deep_update_config(default_dict, user_dict):
@@ -187,7 +284,10 @@ _clash_pool_mode: bool = False
 CLASH_CLUSTER_COUNT: int = 5
 CLASH_SUB_URL: str = ""
 WARP_PROXY_LIST: list = []
+_raw_proxy_enable: bool = False
+RAW_PROXY_LIST: list = []
 PROXY_QUEUE: queue.Queue = queue.Queue()
+PROXY_QUEUE_GENERATION: int = 0
 AI_API_BASE: str = ""
 AI_API_KEY: str = ""
 AI_MODEL: str = "gpt-3.5-turbo"
@@ -222,7 +322,8 @@ def reload_all_configs(new_config_dict=None):
     global MIN_REMAINING_WEEKLY_PERCENT, REMOVE_ON_LIMIT_REACHED, REMOVE_DEAD_ACCOUNTS
     global CPA_THREADS, CHECK_INTERVAL_MINUTES, ENABLE_TOKEN_REVIVE
     global NORMAL_SLEEP_MIN, NORMAL_SLEEP_MAX, NORMAL_TARGET_COUNT
-    global _clash_enable, _clash_pool_mode, WARP_PROXY_LIST, PROXY_QUEUE
+    global _clash_enable, _clash_pool_mode, WARP_PROXY_LIST, PROXY_QUEUE, PROXY_QUEUE_GENERATION
+    global _raw_proxy_enable, RAW_PROXY_LIST
     global CLASH_CLUSTER_COUNT, CLASH_SUB_URL
     global ENABLE_SUB2API_MODE, SUB2API_URL, SUB2API_KEY
     global SUB2API_MIN_THRESHOLD, SUB2API_BATCH_COUNT, SUB2API_CHECK_INTERVAL, SUB2API_THREADS, SUB2API_TEST_MODEL
@@ -450,12 +551,24 @@ def reload_all_configs(new_config_dict=None):
     CLASH_CLUSTER_COUNT = int(_clash_conf.get("cluster_count") or 5)
     CLASH_SUB_URL = str(_clash_conf.get("sub_url") or "").strip()
     WARP_PROXY_LIST = _c.get("warp_proxy_list", [])
+    _raw_proxy_conf = _c.get("raw_proxy_pool", {})
+    _raw_proxy_enable = safe_bool(_raw_proxy_conf.get("enable", False), default=False)
+    RAW_PROXY_LIST = normalize_raw_proxy_list(_raw_proxy_conf.get("proxy_list", []))
+    if is_raw_proxy_pool_enabled():
+        _clash_enable = False
+        _clash_pool_mode = False
 
     with PROXY_QUEUE.mutex:
         PROXY_QUEUE.queue.clear()
-    if _clash_enable and _clash_pool_mode and WARP_PROXY_LIST:
+        PROXY_QUEUE.unfinished_tasks = 0
+        PROXY_QUEUE.all_tasks_done.notify_all()
+        PROXY_QUEUE_GENERATION += 1
+    if is_raw_proxy_pool_enabled():
+        for p in RAW_PROXY_LIST:
+            PROXY_QUEUE.put(make_proxy_queue_item(p))
+    elif is_clash_proxy_pool_enabled():
         for p in WARP_PROXY_LIST:
-            PROXY_QUEUE.put(p)
+            PROXY_QUEUE.put(make_proxy_queue_item(p))
     else:
         PROXY_QUEUE.put(DEFAULT_PROXY if DEFAULT_PROXY else None)
 

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -880,6 +880,14 @@ def normal_main_loop(args, stop_event: threading.Event):
 
                 def _worker():
                     if stop_event.is_set(): return "stopped"
+                    if cfg.is_raw_proxy_pool_enabled():
+                        borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                        try:
+                            return run_and_refresh(p, args, False, skip_switch=True)
+                        finally:
+                            if cfg.should_return_pooled_proxy(borrowed_generation):
+                                cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                                cfg.PROXY_QUEUE.task_done()
                     if cfg._clash_enable and cfg._clash_pool_mode:
                         p = cfg.PROXY_QUEUE.get()
                         try:
@@ -895,7 +903,15 @@ def normal_main_loop(args, stop_event: threading.Event):
                         if f.result() == "success":
                             success_count += 1
             else:
-                if cfg._clash_enable and cfg._clash_pool_mode:
+                if cfg.is_raw_proxy_pool_enabled():
+                    borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                    try:
+                        status = run_and_refresh(p, args, False, skip_switch=True)
+                    finally:
+                        if cfg.should_return_pooled_proxy(borrowed_generation):
+                            cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                            cfg.PROXY_QUEUE.task_done()
+                elif cfg._clash_enable and cfg._clash_pool_mode:
                     p = cfg.PROXY_QUEUE.get()
                     try:
                         status = run_and_refresh(p, args, False, skip_switch=False)
@@ -1034,6 +1050,14 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event):
 
                 def _cpa_worker():
                     if async_stop_event.is_set(): return "stopped"
+                    if cfg.is_raw_proxy_pool_enabled():
+                        borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                        try:
+                            return run_and_refresh(p, args, cpa_upload=True, skip_switch=True)
+                        finally:
+                            if cfg.should_return_pooled_proxy(borrowed_generation):
+                                cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                                cfg.PROXY_QUEUE.task_done()
                     if cfg._clash_enable and cfg._clash_pool_mode:
                         p = cfg.PROXY_QUEUE.get()
                         try:
@@ -1069,7 +1093,15 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event):
                                 await asyncio.sleep(15)
                     else:
                         print(f"[{ts()}] [INFO] 单线程补货: {success_in_this_cycle}/{need_to_reg}")
-                        if cfg._clash_enable and cfg._clash_pool_mode:
+                        if cfg.is_raw_proxy_pool_enabled():
+                            borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                            try:
+                                status = await loop.run_in_executor(None, run_and_refresh, p, args, True, True)
+                            finally:
+                                if cfg.should_return_pooled_proxy(borrowed_generation):
+                                    cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                                    cfg.PROXY_QUEUE.task_done()
+                        elif cfg._clash_enable and cfg._clash_pool_mode:
                             p = cfg.PROXY_QUEUE.get()
                             try:
                                 status = await loop.run_in_executor(None, run_and_refresh, p, args, True, False)
@@ -1184,6 +1216,14 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
 
                 def _sub2api_worker():
                     if async_stop_event.is_set(): return "stopped"
+                    if cfg.is_raw_proxy_pool_enabled():
+                        borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                        try:
+                            return _sub2api_run_wrapper(p, True)
+                        finally:
+                            if cfg.should_return_pooled_proxy(borrowed_generation):
+                                cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                                cfg.PROXY_QUEUE.task_done()
                     if cfg._clash_enable and cfg._clash_pool_mode:
                         p = cfg.PROXY_QUEUE.get()
                         try:
@@ -1222,7 +1262,15 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
 
                     else:
                         print(f"[{ts()}] [INFO] 单线程补货: {success_in_this_cycle}/{need_to_reg}")
-                        if cfg._clash_enable and cfg._clash_pool_mode:
+                        if cfg.is_raw_proxy_pool_enabled():
+                            borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
+                            try:
+                                status = await loop.run_in_executor(None, _sub2api_run_wrapper, p, True)
+                            finally:
+                                if cfg.should_return_pooled_proxy(borrowed_generation):
+                                    cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
+                                    cfg.PROXY_QUEUE.task_done()
+                        elif cfg._clash_enable and cfg._clash_pool_mode:
                             p = cfg.PROXY_QUEUE.get()
                             try:
                                 status = await loop.run_in_executor(None, _sub2api_run_wrapper, p, False)


### PR DESCRIPTION
﻿## Summary

This PR adds an independent `raw_proxy_pool` that works separately from the existing Clash pool.

It supports batch importing:

- `http://...`
- `https://...`
- `socks5://...`
- `socks5h://...`

Entries without a scheme such as `host:port` / `host:port:user:pass` / `user:pass@host:port` are still supported and default to `socks5h`.

## Changes

- add `raw_proxy_pool.enable`
- add `raw_proxy_pool.proxy_list`
- make raw proxy pool take priority over `warp_proxy_list`
- skip Clash node switching when using raw proxies
- keep proxy rotation queue-based and preserve config-order round-robin behavior
- prevent stale proxies from being re-queued after config reload
- add a separate UI card for the batch proxy pool
- add tests for raw proxy parsing and queue reload behavior

## Test

```bash
PYTHONPATH=E:\Project\openai-cpa-upstream python tests\test_raw_proxy_pool.py
python -m py_compile utils\config.py utils\core_engine.py tests\test_raw_proxy_pool.py
node --check static\js\app.js
```
