### PR TITLE
feat(ui): add eye-care dark mode and refine dark palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
                 </div>
             </transition-group>
         </div>
-
         <div v-if="confirmModal.show" class="fixed inset-0 z-[10000] flex items-center justify-center bg-slate-900/40 backdrop-blur-sm transition-opacity p-4">
             <div class="bg-white rounded-2xl shadow-2xl p-6 md:p-8 w-full max-w-md transform transition-all scale-100 border border-slate-100">
                 <h3 class="text-lg md:text-xl font-extrabold text-slate-800 mb-4 flex items-center gap-2">
@@ -85,6 +84,9 @@
                 </div>
                 <button @click="handleLogin" class="w-full bg-gradient-to-r from-indigo-600 to-blue-600 hover:from-indigo-700 hover:to-blue-700 text-white font-bold py-3.5 px-4 rounded-xl text-sm md:text-base focus:outline-none shadow-lg shadow-indigo-500/30 transform active:scale-[0.98] transition-all">
                     安全登录
+                </button>
+                <button @click="toggleTheme" class="w-full mt-3 bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold py-2.5 px-4 rounded-xl text-sm md:text-base border border-slate-200 transition-all active:scale-[0.98]">
+                    {{ isDarkMode ? '☀️ 日间模式' : '🌙 护眼模式' }}
                 </button>
                 <div class="text-center mt-6">
                     <span class="text-[11px] md:text-xs text-slate-400 font-mono tracking-widest font-semibold">{{ appVersion }}</span>
@@ -166,6 +168,9 @@
                         </div>
 
                         <div class="flex items-center justify-between md:justify-end gap-3 md:gap-4 w-full md:w-auto">
+                            <button @click="toggleTheme" class="px-4 py-2 md:px-5 md:py-2.5 rounded-xl font-bold text-xs md:text-sm border transition-all active:scale-95 shrink-0 bg-white text-slate-700 border-slate-200 hover:bg-slate-50 shadow-sm">
+                                {{ isDarkMode ? '☀️ 日间' : '🌙 护眼' }}
+                            </button>
                             <span v-if="isRunning" class="flex items-center gap-2 text-emerald-600 text-[11px] md:text-sm font-bold bg-white px-3 md:px-4 py-1.5 rounded-full border border-slate-200 shadow-sm">
                                 <span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse shadow-[0_0_5px_rgba(16,185,129,0.8)]"></span> 运行中
                             </span>
@@ -2562,6 +2567,15 @@
     </div>
 </div>
     </div>
+    <script>
+        (function () {
+            try {
+                if (localStorage.getItem('ui_theme_mode') === 'dark') {
+                    document.body.classList.add('theme-dark');
+                }
+            } catch (e) {}
+        })();
+    </script>
     <script src="/static/js/app.js?v=__VER__"></script>
 </body>
 </html>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -18,3 +18,98 @@ body { background-color: #f3f4f6; }
 [v-cloak] { display: none !important; }
 .fake-password-mask {-webkit-text-security: disc !important;text-security: disc !important;}
 .mask-text {-webkit-text-security: disc !important;text-security: disc !important;}
+
+body.theme-dark {
+    background-color: #0b0f14 !important;
+    color: #dbe4ee;
+}
+
+body.theme-dark [class*="radial-gradient"] {
+    background-image: radial-gradient(ellipse at top right, #172033 0%, #0b111a 46%, #070b12 100%) !important;
+}
+
+body.theme-dark [class*="bg-white"],
+body.theme-dark [class*="from-white"],
+body.theme-dark [class*="to-white"] {
+    background-color: #121821 !important;
+}
+
+body.theme-dark [class*="bg-slate-50"],
+body.theme-dark [class*="bg-slate-100"],
+body.theme-dark [class*="bg-slate-200"] {
+    background-color: #0f1722 !important;
+}
+
+body.theme-dark [class*="bg-indigo-50"],
+body.theme-dark [class*="bg-blue-50"],
+body.theme-dark [class*="bg-sky-50"],
+body.theme-dark [class*="bg-cyan-50"] {
+    background-color: #122033 !important;
+}
+
+body.theme-dark [class*="bg-amber-50"],
+body.theme-dark [class*="bg-rose-50"],
+body.theme-dark [class*="bg-emerald-50"],
+body.theme-dark [class*="bg-green-50"],
+body.theme-dark [class*="bg-purple-50"] {
+    background-color: #1a2230 !important;
+}
+
+body.theme-dark [class*="from-indigo-100"] {
+    --tw-gradient-from: #1a2740 var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(26 39 64 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="via-slate-50"] {
+    --tw-gradient-stops: var(--tw-gradient-from), #0c131e var(--tw-gradient-via-position), var(--tw-gradient-to) !important;
+}
+
+body.theme-dark [class*="border-slate-"],
+body.theme-dark [class*="border-white"] {
+    border-color: #283548 !important;
+}
+
+body.theme-dark [class*="border-indigo-"],
+body.theme-dark [class*="border-blue-"],
+body.theme-dark [class*="border-sky-"],
+body.theme-dark [class*="border-cyan-"] {
+    border-color: #2a4062 !important;
+}
+
+body.theme-dark [class*="border-amber-"],
+body.theme-dark [class*="border-rose-"],
+body.theme-dark [class*="border-emerald-"],
+body.theme-dark [class*="border-green-"],
+body.theme-dark [class*="border-purple-"] {
+    border-color: #3a4354 !important;
+}
+
+body.theme-dark [class*="text-slate-900"],
+body.theme-dark [class*="text-slate-800"],
+body.theme-dark [class*="text-slate-700"],
+body.theme-dark [class*="text-slate-600"],
+body.theme-dark [class*="text-slate-500"],
+body.theme-dark [class*="text-slate-400"] {
+    color: #d1d9e3 !important;
+}
+
+body.theme-dark [class*="text-indigo-700"],
+body.theme-dark [class*="text-indigo-600"] {
+    color: #a8bbff !important;
+}
+
+body.theme-dark input,
+body.theme-dark textarea,
+body.theme-dark select {
+    background-color: #0d141f !important;
+    color: #dbe4ee !important;
+    border-color: #334155 !important;
+}
+
+body.theme-dark ::-webkit-scrollbar-thumb {
+    background: #3a4a63;
+}
+
+body.theme-dark ::-webkit-scrollbar-thumb:hover {
+    background: #516584;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,46 +22,156 @@ body { background-color: #f3f4f6; }
 body.theme-dark {
     background-color: #0b0f14 !important;
     color: #dbe4ee;
+    --theme-dark-surface: #121821;
+    --theme-dark-surface-muted: #0f1722;
+    --theme-dark-surface-glass: rgba(15, 23, 34, 0.84);
+    --theme-dark-panel-indigo: #162338;
+    --theme-dark-panel-blue: #112333;
+    --theme-dark-panel-sky: #122734;
+    --theme-dark-panel-emerald: #13261f;
+    --theme-dark-panel-amber: #211f16;
+    --theme-dark-panel-orange: #241d14;
+    --theme-dark-panel-purple: #1b1d2d;
+    --theme-dark-panel-rose: #261a21;
 }
 
 body.theme-dark [class*="radial-gradient"] {
     background-image: radial-gradient(ellipse at top right, #172033 0%, #0b111a 46%, #070b12 100%) !important;
 }
 
+body.theme-dark [class*="bg-white/"],
+body.theme-dark [class*="bg-slate-50/"],
+body.theme-dark [class*="bg-slate-100/"] {
+    background-color: var(--theme-dark-surface-glass) !important;
+}
+
 body.theme-dark [class*="bg-white"],
 body.theme-dark [class*="from-white"],
 body.theme-dark [class*="to-white"] {
-    background-color: #121821 !important;
+    background-color: var(--theme-dark-surface) !important;
+    --tw-gradient-to: rgb(11 17 26 / 0.98) var(--tw-gradient-to-position) !important;
 }
 
 body.theme-dark [class*="bg-slate-50"],
 body.theme-dark [class*="bg-slate-100"],
 body.theme-dark [class*="bg-slate-200"] {
-    background-color: #0f1722 !important;
+    background-color: var(--theme-dark-surface-muted) !important;
 }
 
 body.theme-dark [class*="bg-indigo-50"],
 body.theme-dark [class*="bg-blue-50"],
 body.theme-dark [class*="bg-sky-50"],
 body.theme-dark [class*="bg-cyan-50"] {
-    background-color: #122033 !important;
+    background-color: var(--theme-dark-panel-blue) !important;
 }
 
 body.theme-dark [class*="bg-amber-50"],
-body.theme-dark [class*="bg-rose-50"],
-body.theme-dark [class*="bg-emerald-50"],
-body.theme-dark [class*="bg-green-50"],
-body.theme-dark [class*="bg-purple-50"] {
-    background-color: #1a2230 !important;
+body.theme-dark [class*="bg-orange-50"] {
+    background-color: var(--theme-dark-panel-amber) !important;
 }
 
+body.theme-dark [class*="bg-emerald-50"],
+body.theme-dark [class*="bg-green-50"] {
+    background-color: var(--theme-dark-panel-emerald) !important;
+}
+
+body.theme-dark [class*="bg-purple-50"] {
+    background-color: var(--theme-dark-panel-purple) !important;
+}
+
+body.theme-dark [class*="bg-rose-50"] {
+    background-color: var(--theme-dark-panel-rose) !important;
+}
+
+body.theme-dark [class*="from-white"] {
+    --tw-gradient-from: rgb(18 24 33 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(18 24 33 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-slate-50"],
+body.theme-dark [class*="from-slate-100"] {
+    --tw-gradient-from: rgb(15 23 34 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(15 23 34 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-indigo-50"],
 body.theme-dark [class*="from-indigo-100"] {
-    --tw-gradient-from: #1a2740 var(--tw-gradient-from-position) !important;
-    --tw-gradient-to: rgb(26 39 64 / 0) var(--tw-gradient-to-position) !important;
+    --tw-gradient-from: rgb(22 35 56 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(22 35 56 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-blue-50"],
+body.theme-dark [class*="from-sky-50"],
+body.theme-dark [class*="from-cyan-50"] {
+    --tw-gradient-from: rgb(17 35 51 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(17 35 51 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-amber-50"] {
+    --tw-gradient-from: rgb(33 31 22 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(33 31 22 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-orange-50"] {
+    --tw-gradient-from: rgb(36 29 20 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(36 29 20 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-emerald-50"],
+body.theme-dark [class*="from-green-50"] {
+    --tw-gradient-from: rgb(19 38 31 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(19 38 31 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-purple-50"] {
+    --tw-gradient-from: rgb(27 29 45 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(27 29 45 / 0) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="from-rose-50"] {
+    --tw-gradient-from: rgb(38 26 33 / 0.96) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(38 26 33 / 0) var(--tw-gradient-to-position) !important;
 }
 
 body.theme-dark [class*="via-slate-50"] {
     --tw-gradient-stops: var(--tw-gradient-from), #0c131e var(--tw-gradient-via-position), var(--tw-gradient-to) !important;
+}
+
+body.theme-dark [class*="to-white"] {
+    --tw-gradient-to: rgb(11 17 26 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-slate-50"],
+body.theme-dark [class*="to-slate-100"] {
+    --tw-gradient-to: rgb(12 19 30 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-indigo-50"] {
+    --tw-gradient-to: rgb(15 26 42 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-blue-50"],
+body.theme-dark [class*="to-sky-50"],
+body.theme-dark [class*="to-cyan-50"] {
+    --tw-gradient-to: rgb(14 27 40 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-amber-50"],
+body.theme-dark [class*="to-orange-50"] {
+    --tw-gradient-to: rgb(22 18 14 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-emerald-50"],
+body.theme-dark [class*="to-green-50"] {
+    --tw-gradient-to: rgb(14 26 22 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-purple-50"] {
+    --tw-gradient-to: rgb(22 21 38 / 0.98) var(--tw-gradient-to-position) !important;
+}
+
+body.theme-dark [class*="to-rose-50"] {
+    --tw-gradient-to: rgb(28 18 23 / 0.98) var(--tw-gradient-to-position) !important;
 }
 
 body.theme-dark [class*="border-slate-"],
@@ -94,8 +204,45 @@ body.theme-dark [class*="text-slate-400"] {
 }
 
 body.theme-dark [class*="text-indigo-700"],
-body.theme-dark [class*="text-indigo-600"] {
+body.theme-dark [class*="text-indigo-600"],
+body.theme-dark [class*="text-blue-700"],
+body.theme-dark [class*="text-blue-600"],
+body.theme-dark [class*="text-sky-900"],
+body.theme-dark [class*="text-sky-700"],
+body.theme-dark [class*="text-sky-600"],
+body.theme-dark [class*="text-cyan-700"] {
     color: #a8bbff !important;
+}
+
+body.theme-dark [class*="text-emerald-900"],
+body.theme-dark [class*="text-emerald-800"],
+body.theme-dark [class*="text-emerald-700"],
+body.theme-dark [class*="text-green-700"],
+body.theme-dark [class*="text-green-600"] {
+    color: #78d6af !important;
+}
+
+body.theme-dark [class*="text-amber-900"],
+body.theme-dark [class*="text-amber-800"],
+body.theme-dark [class*="text-amber-700"],
+body.theme-dark [class*="text-orange-900"],
+body.theme-dark [class*="text-orange-800"],
+body.theme-dark [class*="text-orange-700"],
+body.theme-dark [class*="text-orange-600"] {
+    color: #f3bf78 !important;
+}
+
+body.theme-dark [class*="text-purple-900"],
+body.theme-dark [class*="text-purple-700"],
+body.theme-dark [class*="text-purple-600"],
+body.theme-dark [class*="text-purple-500"] {
+    color: #c7b9ff !important;
+}
+
+body.theme-dark [class*="text-rose-700"],
+body.theme-dark [class*="text-rose-600"],
+body.theme-dark [class*="text-rose-500"] {
+    color: #f3a9b7 !important;
 }
 
 body.theme-dark input,
@@ -104,6 +251,11 @@ body.theme-dark select {
     background-color: #0d141f !important;
     color: #dbe4ee !important;
     border-color: #334155 !important;
+}
+
+body.theme-dark input::placeholder,
+body.theme-dark textarea::placeholder {
+    color: #718198 !important;
 }
 
 body.theme-dark ::-webkit-scrollbar-thumb {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -7,6 +7,7 @@ createApp({
             isLoggedIn: !!localStorage.getItem('auth_token'),
             loginPassword: '',
             currentTab: window.location.hash.replace('#', '') || 'console',
+            isDarkMode: localStorage.getItem('ui_theme_mode') === 'dark',
 			showAccountsPlaintext: false,
             isRunning: false,
             tabs: [
@@ -143,6 +144,7 @@ createApp({
         };
     },
     mounted() {
+        this.applyTheme();
         if (this.isLoggedIn) {
             this.initApp();
         }
@@ -171,6 +173,16 @@ createApp({
         }
     },
     methods: {
+        applyTheme() {
+            const nextMode = this.isDarkMode ? 'dark' : 'light';
+            document.body.classList.toggle('theme-dark', this.isDarkMode);
+            localStorage.setItem('ui_theme_mode', nextMode);
+        },
+        toggleTheme() {
+            this.isDarkMode = !this.isDarkMode;
+            this.applyTheme();
+            this.showToast(this.isDarkMode ? '已切换为护眼模式' : '已切换为日间模式', 'info');
+        },
         showToast(message, type = 'info') {
             const id = this.toastId++;
             this.toasts.push({ id, message, type });

--- a/tests/test_eye_care_dark_mode_theme.py
+++ b/tests/test_eye_care_dark_mode_theme.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = (ROOT / "index.html").read_text(encoding="utf-8")
+CSS = (ROOT / "static/css/style.css").read_text(encoding="utf-8")
+
+
+def test_eye_care_dark_mode_redefines_light_gradient_start_tokens():
+    light_gradient_starts = [
+        "from-white",
+        "from-slate-50",
+        "from-indigo-50",
+        "from-sky-50",
+        "from-blue-50",
+        "from-amber-50",
+        "from-orange-50",
+        "from-emerald-50",
+        "from-purple-50",
+        "from-rose-50",
+    ]
+
+    for token in light_gradient_starts:
+        if token in HTML:
+            assert f'[class*="{token}"]' in CSS, f"missing dark-mode override for {token}"
+
+
+def test_eye_care_dark_mode_redefines_light_gradient_end_tokens():
+    light_gradient_ends = [
+        "to-white",
+        "to-blue-50",
+        "to-indigo-50",
+        "to-slate-50",
+    ]
+
+    for token in light_gradient_ends:
+        if token in HTML:
+            selector = f'body.theme-dark [class*="{token}"]'
+            assert selector in CSS, f"missing dark-mode selector for {token}"
+            start = CSS.index(selector)
+            end = CSS.find("}", start)
+            block = CSS[start:end]
+            assert "--tw-gradient-to" in block or "--tw-gradient-stops" in block, (
+                f"{token} still needs a dark-mode gradient override"
+            )


### PR DESCRIPTION
### Summary
This PR adds an eye-care dark mode toggle for the web console and improves dark-theme consistency across the login page and dashboard.

The theme preference is persisted locally, so users keep the same theme after refresh.
No backend/API behavior changes.

### Changes
- Add dark/light toggle on login and main header
- Save theme in `localStorage` (`ui_theme_mode`)
- Auto-apply saved theme on page load
- Refine dark colors for light backgrounds, small containers, and borders