### PR TITLE
fix: issue43 Sub2API proxy pool for auth push

### DIFF
--- a/index.html
+++ b/index.html
@@ -2207,11 +2207,12 @@
                                             </div>
                                         </div>
                                         <div class="col-span-2 bg-white p-4 rounded-xl border border-slate-200 shadow-sm hover:border-purple-300 transition-colors mt-1">
-                                            <label class="block text-[11px] text-slate-500 font-black mb-2 uppercase tracking-wider">专属代理</label>
-                                            <input type="text" v-model="config.sub2api_mode.default_proxy"
-                                                   class="w-full appearance-none bg-slate-50 border border-slate-200 text-slate-700 font-mono text-sm rounded-lg py-2.5 px-4 focus:outline-none focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 transition-colors shadow-sm placeholder:text-slate-400"
-                                                   placeholder="格式: socks5://user:pass@1.1.1.1:1080 http://192.168.1.1:8080 https://user:pass@proxy.example.com:443 (支持 socks5/http/https)">
-                                            <p class="text-[11px] text-slate-400 font-medium mt-2">💡 填写后，推送时会一起提交给sub2api。</p>
+                                            <label class="block text-[11px] text-slate-500 font-black mb-2 uppercase tracking-wider">专属代理池</label>
+                                            <textarea v-model="config.sub2api_mode.default_proxy"
+                                                      rows="4"
+                                                      class="w-full appearance-none bg-slate-50 border border-slate-200 text-slate-700 font-mono text-sm rounded-lg py-2.5 px-4 focus:outline-none focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 transition-colors shadow-sm placeholder:text-slate-400 resize-y"
+                                                      placeholder="每行 1 个代理&#10;&#10;示例:&#10;socks5://user:pass@1.1.1.1:1080&#10;http://2.2.2.2:8080&#10;https://user:pass@proxy.example.com:443"></textarea>
+                                            <p class="text-[11px] text-slate-400 font-medium mt-2">💡 仅用于 Sub2API 推送与导出。0 行 = 不带代理，1 行 = 固定代理，2+ 行 = 按顺序轮转。</p>
                                         </div>
                                         <div class="col-span-2 bg-purple-50/50 p-5 md:p-6 rounded-2xl border border-purple-200 mt-2 space-y-6 shadow-sm">
                                             <h4 class="text-sm md:text-base font-black text-purple-800 flex items-center gap-2 pb-3 border-b border-purple-200/60 uppercase tracking-widest">

--- a/routers/api_routes.py
+++ b/routers/api_routes.py
@@ -18,7 +18,7 @@ from typing import List, Optional, Any
 from cloudflare import Cloudflare
 from utils import core_engine, db_manager
 from utils.config import reload_all_configs
-from utils.integrations.sub2api_client import Sub2APIClient
+from utils.integrations.sub2api_client import Sub2APIClient, build_sub2api_export_bundle, get_sub2api_push_settings
 from utils.integrations.tg_notifier import send_tg_msg_async
 from utils.email_providers.gmail_oauth_handler import GmailOAuthHandler
 from curl_cffi import requests as cffi_requests
@@ -505,9 +505,6 @@ def account_action(data: dict, token: str = Depends(verify_token)):
         elif action == "push_sub2api":
             if not getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False): return {"status": "error",
                                                                                    "message": "🚫 推送失败：未开启 Sub2API 模式！"}
-            proxy_obj = parse_sub2api_proxy(cfg.SUB2API_DEFAULT_PROXY)
-            if proxy_obj:
-                token_data["sub2api_proxy"] = proxy_obj
             client = Sub2APIClient(api_url=getattr(core_engine.cfg, 'SUB2API_URL', ''),
                                    api_key=getattr(core_engine.cfg, 'SUB2API_KEY', ''))
             success, resp = client.add_account(token_data)
@@ -524,25 +521,8 @@ async def export_sub2api_accounts(req: ExportReq, token: str = Depends(verify_to
         tokens = db_manager.get_tokens_by_emails(req.emails)
         if not tokens: return {"status": "error", "message": "未提取到Token"}
 
-        sub2api_settings = getattr(core_engine.cfg, '_c', {}).get("sub2api_mode", {})
-        proxy_obj = parse_sub2api_proxy(cfg.SUB2API_DEFAULT_PROXY)
-        accounts_list = []
-        for td in tokens:
-            acc = {
-                "name": str(td.get("email", "unknown"))[:64],
-                "platform": "openai", "type": "oauth",
-                "credentials": {"refresh_token": td.get("refresh_token", "")},
-                "concurrency": int(sub2api_settings.get("account_concurrency", 10)),
-                "priority": int(sub2api_settings.get("account_priority", 1)),
-                "rate_multiplier": float(sub2api_settings.get("account_rate_multiplier", 1.0)),
-                "extra": {"load_factor": int(sub2api_settings.get("account_load_factor", 10))}
-            }
-            if proxy_obj:
-                acc["proxy_key"] = proxy_obj["proxy_key"]
-            accounts_list.append(acc)
-        return {"status": "success",
-                "data": {"exported_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "proxies": [proxy_obj] if proxy_obj else [],
-                         "accounts": accounts_list}}
+        bundle = build_sub2api_export_bundle(tokens, get_sub2api_push_settings(), rotate_missing_proxy=True)
+        return {"status": "success", "data": bundle}
     except Exception as e:
         return {"status": "error", "message": str(e)}
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -325,6 +325,9 @@ createApp({
                 if (this.config.sub2api_mode.test_model === undefined) {
                     this.config.sub2api_mode.test_model = 'gpt-5.2';
                 }
+                if (Array.isArray(this.config.sub2api_mode.default_proxy)) {
+                    this.config.sub2api_mode.default_proxy = this.config.sub2api_mode.default_proxy.join('\n');
+                }
                 if (this.config.sub2api_mode.default_proxy === undefined) {
                     this.config.sub2api_mode.default_proxy = '';
                 }
@@ -405,6 +408,13 @@ createApp({
                     this.config.clash_proxy_pool.blacklist = this.blacklistStr.split('\n').map(s => s.trim()).filter(s => s);
                     this.config.clash_proxy_pool.cluster_count = parseInt(this.clashPool.count) || 5;
                     this.config.clash_proxy_pool.sub_url = this.clashPool.subUrl;
+                }
+                if (this.config?.sub2api_mode) {
+                    this.config.sub2api_mode.default_proxy = String(this.config.sub2api_mode.default_proxy || '')
+                        .split(/\r?\n/)
+                        .map(s => s.trim())
+                        .filter(s => s)
+                        .join('\n');
                 }
                 if (this.config.local_microsoft) {
                     const mode = String(this.config.local_microsoft.suffix_mode || 'fixed').toLowerCase();
@@ -2112,9 +2122,7 @@ createApp({
                     const cpaFolder = zip.folder("cpa");
                     const sub2apiFolder = zip.folder("sub2api");
 
-                    const proxyUrl = this.config?.sub2api_mode?.default_proxy || "";
-                    const proxyObj = this.parseSub2ApiProxy(proxyUrl);
-                    const proxiesArray = proxyObj ? [proxyObj] : [];
+                    const proxyPool = this.buildSub2ApiProxyPool(this.config?.sub2api_mode?.default_proxy || "");
 
                     const validAccounts = allData.filter(acc => acc.token_data && acc.token_data.access_token);
 
@@ -2131,8 +2139,9 @@ createApp({
                         };
                         cpaFolder.file(`token_${prefix}_${domain}_${timestamp + index}.json`, JSON.stringify(cpaData, null, 4));
 
+                        const proxyObj = proxyPool.length ? proxyPool[index % proxyPool.length] : null;
                         const accountNode = {
-                            name: accEmail,
+                            name: accEmail.slice(0, 64),
                             platform: "openai",
                             type: "oauth",
                             credentials: { refresh_token: acc.token_data.refresh_token || "" },
@@ -2148,7 +2157,7 @@ createApp({
 
                         const sub2apiData = {
                             exported_at: new Date().toISOString(),
-                            proxies: proxiesArray,
+                            proxies: proxyObj ? [proxyObj] : [],
                             accounts: [accountNode]
                         };
                         sub2apiFolder.file(`sub2api_${prefix}_${domain}_${timestamp + index}.json`, JSON.stringify(sub2apiData, null, 4));
@@ -2278,6 +2287,25 @@ createApp({
             } catch (e) {
                 return null;
             }
+        },
+        buildSub2ApiProxyPool(rawValue) {
+            const rawItems = Array.isArray(rawValue)
+                ? rawValue
+                : String(rawValue || '').replace(/\r/g, '\n').split('\n');
+
+            const proxyPool = [];
+            const seen = new Set();
+            rawItems.forEach(item => {
+                const value = String(item || '').trim();
+                if (!value || seen.has(value)) return;
+                seen.add(value);
+
+                const proxyObj = this.parseSub2ApiProxy(value);
+                if (proxyObj) {
+                    proxyPool.push(proxyObj);
+                }
+            });
+            return proxyPool;
         },
     }
 }).mount('#app');

--- a/tests/test_sub2api_proxy_pool.py
+++ b/tests/test_sub2api_proxy_pool.py
@@ -1,0 +1,140 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+fake_requests_module = types.SimpleNamespace(
+    post=None,
+    get=None,
+    put=None,
+    patch=None,
+    delete=None,
+    Response=object,
+    exceptions=types.SimpleNamespace(ConnectionError=Exception, Timeout=TimeoutError),
+)
+sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
+sys.modules.setdefault("requests", types.SimpleNamespace(get=None, put=None))
+sys.modules["yaml"] = types.SimpleNamespace(
+    safe_load=lambda *args, **kwargs: {},
+    dump=lambda *args, **kwargs: None,
+)
+
+from utils import config as cfg
+from utils.integrations.sub2api_client import Sub2APIClient, build_sub2api_export_bundle, get_sub2api_push_settings
+from utils.integrations.sub2api_proxy import normalize_sub2api_proxy_urls
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class Sub2APIProxyPoolTests(unittest.TestCase):
+    def setUp(self):
+        self.cfg_patches = [
+            patch.object(cfg, "SUB2API_DEFAULT_PROXY", "socks5://user1:pass1@1.1.1.1:1080\nhttp://2.2.2.2:8080"),
+            patch.object(cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10),
+            patch.object(cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10),
+            patch.object(cfg, "SUB2API_ACCOUNT_PRIORITY", 1),
+            patch.object(cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0),
+            patch.object(cfg, "SUB2API_ACCOUNT_GROUP_IDS", []),
+            patch.object(cfg, "SUB2API_ENABLE_WS_MODE", True),
+        ]
+        for item in self.cfg_patches:
+            item.start()
+        setattr(
+            cfg,
+            "SUB2API_DEFAULT_PROXY_POOL",
+            [
+                "socks5://user1:pass1@1.1.1.1:1080",
+                "http://2.2.2.2:8080",
+            ],
+        )
+        reset_rotation = getattr(cfg, "reset_sub2api_proxy_rotation", None)
+        if callable(reset_rotation):
+            reset_rotation()
+
+    def tearDown(self):
+        for item in reversed(self.cfg_patches):
+            item.stop()
+
+    def test_add_account_rotates_proxy_pool_and_uses_import_endpoint(self):
+        captured_posts = []
+
+        def fake_post(url, json=None, headers=None, **kwargs):
+            captured_posts.append({"url": url, "json": json, "headers": headers})
+            if url.endswith("/api/v1/admin/accounts/data"):
+                return _FakeResponse(201, {"status": "ok"})
+            if url.endswith("/api/v1/admin/accounts"):
+                return _FakeResponse(201, {"data": {}})
+            raise AssertionError(f"unexpected url: {url}")
+
+        token_a = {"email": "alpha@example.com", "refresh_token": "rt-alpha"}
+        token_b = {"email": "beta@example.com", "refresh_token": "rt-beta"}
+
+        with patch("utils.integrations.sub2api_client.cffi_requests.post", side_effect=fake_post):
+            client = Sub2APIClient(api_url="https://sub2api.example", api_key="demo-key")
+            ok_a, _ = client.add_account(dict(token_a))
+            ok_b, _ = client.add_account(dict(token_b))
+
+        self.assertTrue(ok_a)
+        self.assertTrue(ok_b)
+        self.assertEqual(
+            [
+                "https://sub2api.example/api/v1/admin/accounts/data",
+                "https://sub2api.example/api/v1/admin/accounts/data",
+            ],
+            [item["url"] for item in captured_posts],
+        )
+        first_payload = captured_posts[0]["json"]["data"]
+        second_payload = captured_posts[1]["json"]["data"]
+        self.assertEqual(
+            "socks5|1.1.1.1|1080|user1|pass1",
+            first_payload["accounts"][0]["proxy_key"],
+        )
+        self.assertEqual(
+            "http|2.2.2.2|8080||",
+            second_payload["accounts"][0]["proxy_key"],
+        )
+        self.assertEqual(1, len(first_payload["proxies"]))
+        self.assertEqual(1, len(second_payload["proxies"]))
+
+    def test_reload_all_configs_accepts_list_and_filters_invalid_proxies(self):
+        with patch("utils.config.init_config", return_value={}), \
+                patch("utils.config.reload_proxy_config"):
+            cfg.reload_all_configs({
+                "sub2api_mode": {
+                    "default_proxy": [
+                        "bad-proxy",
+                        "http://2.2.2.2:8080",
+                    ]
+                }
+            })
+
+        cfg.reset_sub2api_proxy_rotation()
+        self.assertEqual(["http://2.2.2.2:8080"], cfg.SUB2API_DEFAULT_PROXY_POOL)
+        self.assertEqual("http://2.2.2.2:8080", cfg.get_next_sub2api_proxy_url())
+
+    def test_export_bundle_truncates_long_account_name(self):
+        email = ("a" * 80) + "@example.com"
+        bundle = build_sub2api_export_bundle(
+            [{"email": email, "refresh_token": "rt-long"}],
+            get_sub2api_push_settings(),
+        )
+        self.assertEqual(email[:64], bundle["accounts"][0]["name"])
+
+    def test_normalize_proxy_urls_preserves_commas_inside_userinfo(self):
+        self.assertEqual(
+            ["http://user:pa,ss@host.example:8080"],
+            normalize_sub2api_proxy_urls("http://user:pa,ss@host.example:8080"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sub2api_proxy_pool.py
+++ b/tests/test_sub2api_proxy_pool.py
@@ -1,28 +1,14 @@
+import importlib
 import sys
 import types
 import unittest
 from unittest.mock import patch
 
 
-fake_requests_module = types.SimpleNamespace(
-    post=None,
-    get=None,
-    put=None,
-    patch=None,
-    delete=None,
-    Response=object,
-    exceptions=types.SimpleNamespace(ConnectionError=Exception, Timeout=TimeoutError),
-)
-sys.modules.setdefault("curl_cffi", types.SimpleNamespace(requests=fake_requests_module))
-sys.modules.setdefault("requests", types.SimpleNamespace(get=None, put=None))
-sys.modules["yaml"] = types.SimpleNamespace(
+_yaml_module = types.SimpleNamespace(
     safe_load=lambda *args, **kwargs: {},
     dump=lambda *args, **kwargs: None,
 )
-
-from utils import config as cfg
-from utils.integrations.sub2api_client import Sub2APIClient, build_sub2api_export_bundle, get_sub2api_push_settings
-from utils.integrations.sub2api_proxy import normalize_sub2api_proxy_urls
 
 
 class _FakeResponse:
@@ -36,33 +22,71 @@ class _FakeResponse:
 
 
 class Sub2APIProxyPoolTests(unittest.TestCase):
+    repo_module_names = [
+        "utils.config",
+        "utils.proxy_manager",
+        "utils.integrations.sub2api_client",
+        "utils.integrations.sub2api_proxy",
+    ]
+
     def setUp(self):
+        fake_requests_module = types.SimpleNamespace(
+            post=None,
+            get=None,
+            put=None,
+            patch=None,
+            delete=None,
+            Response=object,
+            exceptions=types.SimpleNamespace(ConnectionError=Exception, Timeout=TimeoutError),
+        )
+
+        self.original_modules = {}
+        for module_name in ["curl_cffi", "requests", "yaml", *self.repo_module_names]:
+            if module_name in sys.modules:
+                self.original_modules[module_name] = sys.modules[module_name]
+            sys.modules.pop(module_name, None)
+
+        sys.modules["curl_cffi"] = types.SimpleNamespace(requests=fake_requests_module)
+        sys.modules["requests"] = types.SimpleNamespace(get=None, put=None)
+        sys.modules["yaml"] = _yaml_module
+
+        self.cfg = importlib.import_module("utils.config")
+        self.proxy_module = importlib.import_module("utils.integrations.sub2api_proxy")
+        self.client_module = importlib.import_module("utils.integrations.sub2api_client")
+
+        self.Sub2APIClient = self.client_module.Sub2APIClient
+        self.build_sub2api_export_bundle = self.client_module.build_sub2api_export_bundle
+        self.get_sub2api_push_settings = self.client_module.get_sub2api_push_settings
+        self.normalize_sub2api_proxy_urls = self.proxy_module.normalize_sub2api_proxy_urls
+
         self.cfg_patches = [
-            patch.object(cfg, "SUB2API_DEFAULT_PROXY", "socks5://user1:pass1@1.1.1.1:1080\nhttp://2.2.2.2:8080"),
-            patch.object(cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10),
-            patch.object(cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10),
-            patch.object(cfg, "SUB2API_ACCOUNT_PRIORITY", 1),
-            patch.object(cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0),
-            patch.object(cfg, "SUB2API_ACCOUNT_GROUP_IDS", []),
-            patch.object(cfg, "SUB2API_ENABLE_WS_MODE", True),
+            patch.object(self.cfg, "SUB2API_DEFAULT_PROXY", "socks5://user1:pass1@1.1.1.1:1080\nhttp://2.2.2.2:8080"),
+            patch.object(self.cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10),
+            patch.object(self.cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10),
+            patch.object(self.cfg, "SUB2API_ACCOUNT_PRIORITY", 1),
+            patch.object(self.cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0),
+            patch.object(self.cfg, "SUB2API_ACCOUNT_GROUP_IDS", []),
+            patch.object(self.cfg, "SUB2API_ENABLE_WS_MODE", True),
         ]
         for item in self.cfg_patches:
             item.start()
         setattr(
-            cfg,
+            self.cfg,
             "SUB2API_DEFAULT_PROXY_POOL",
             [
                 "socks5://user1:pass1@1.1.1.1:1080",
                 "http://2.2.2.2:8080",
             ],
         )
-        reset_rotation = getattr(cfg, "reset_sub2api_proxy_rotation", None)
-        if callable(reset_rotation):
-            reset_rotation()
+        self.cfg.reset_sub2api_proxy_rotation()
 
     def tearDown(self):
         for item in reversed(self.cfg_patches):
             item.stop()
+
+        for module_name in ["curl_cffi", "requests", "yaml", *self.repo_module_names]:
+            sys.modules.pop(module_name, None)
+        sys.modules.update(self.original_modules)
 
     def test_add_account_rotates_proxy_pool_and_uses_import_endpoint(self):
         captured_posts = []
@@ -78,8 +102,8 @@ class Sub2APIProxyPoolTests(unittest.TestCase):
         token_a = {"email": "alpha@example.com", "refresh_token": "rt-alpha"}
         token_b = {"email": "beta@example.com", "refresh_token": "rt-beta"}
 
-        with patch("utils.integrations.sub2api_client.cffi_requests.post", side_effect=fake_post):
-            client = Sub2APIClient(api_url="https://sub2api.example", api_key="demo-key")
+        with patch.object(self.client_module.cffi_requests, "post", side_effect=fake_post):
+            client = self.Sub2APIClient(api_url="https://sub2api.example", api_key="demo-key")
             ok_a, _ = client.add_account(dict(token_a))
             ok_b, _ = client.add_account(dict(token_b))
 
@@ -105,10 +129,56 @@ class Sub2APIProxyPoolTests(unittest.TestCase):
         self.assertEqual(1, len(first_payload["proxies"]))
         self.assertEqual(1, len(second_payload["proxies"]))
 
+    def test_add_account_preserves_zero_and_single_proxy_semantics(self):
+        captured_posts = []
+
+        def fake_post(url, json=None, headers=None, **kwargs):
+            captured_posts.append({"url": url, "json": json, "headers": headers})
+            if url.endswith("/api/v1/admin/accounts/data"):
+                return _FakeResponse(201, {"status": "ok"})
+            if url.endswith("/api/v1/admin/accounts"):
+                return _FakeResponse(201, {"data": {}})
+            raise AssertionError(f"unexpected url: {url}")
+
+        with patch.object(self.client_module.cffi_requests, "post", side_effect=fake_post):
+            client = self.Sub2APIClient(api_url="https://sub2api.example", api_key="demo-key")
+
+            self.cfg.SUB2API_DEFAULT_PROXY = ""
+            self.cfg.SUB2API_DEFAULT_PROXY_POOL = []
+            self.cfg.reset_sub2api_proxy_rotation()
+            ok_zero, _ = client.add_account({"email": "zero@example.com", "refresh_token": "rt-zero"})
+
+            self.cfg.SUB2API_DEFAULT_PROXY = "http://2.2.2.2:8080"
+            self.cfg.SUB2API_DEFAULT_PROXY_POOL = ["http://2.2.2.2:8080"]
+            self.cfg.reset_sub2api_proxy_rotation()
+            ok_one_a, _ = client.add_account({"email": "one-a@example.com", "refresh_token": "rt-one-a"})
+            ok_one_b, _ = client.add_account({"email": "one-b@example.com", "refresh_token": "rt-one-b"})
+
+        self.assertTrue(ok_zero)
+        self.assertTrue(ok_one_a)
+        self.assertTrue(ok_one_b)
+        self.assertEqual(
+            [
+                "https://sub2api.example/api/v1/admin/accounts",
+                "https://sub2api.example/api/v1/admin/accounts/data",
+                "https://sub2api.example/api/v1/admin/accounts/data",
+            ],
+            [item["url"] for item in captured_posts],
+        )
+        self.assertNotIn("proxy_key", captured_posts[0]["json"])
+        self.assertEqual(
+            "http|2.2.2.2|8080||",
+            captured_posts[1]["json"]["data"]["accounts"][0]["proxy_key"],
+        )
+        self.assertEqual(
+            "http|2.2.2.2|8080||",
+            captured_posts[2]["json"]["data"]["accounts"][0]["proxy_key"],
+        )
+
     def test_reload_all_configs_accepts_list_and_filters_invalid_proxies(self):
         with patch("utils.config.init_config", return_value={}), \
                 patch("utils.config.reload_proxy_config"):
-            cfg.reload_all_configs({
+            self.cfg.reload_all_configs({
                 "sub2api_mode": {
                     "default_proxy": [
                         "bad-proxy",
@@ -117,22 +187,22 @@ class Sub2APIProxyPoolTests(unittest.TestCase):
                 }
             })
 
-        cfg.reset_sub2api_proxy_rotation()
-        self.assertEqual(["http://2.2.2.2:8080"], cfg.SUB2API_DEFAULT_PROXY_POOL)
-        self.assertEqual("http://2.2.2.2:8080", cfg.get_next_sub2api_proxy_url())
+        self.cfg.reset_sub2api_proxy_rotation()
+        self.assertEqual(["http://2.2.2.2:8080"], self.cfg.SUB2API_DEFAULT_PROXY_POOL)
+        self.assertEqual("http://2.2.2.2:8080", self.cfg.get_next_sub2api_proxy_url())
 
     def test_export_bundle_truncates_long_account_name(self):
         email = ("a" * 80) + "@example.com"
-        bundle = build_sub2api_export_bundle(
+        bundle = self.build_sub2api_export_bundle(
             [{"email": email, "refresh_token": "rt-long"}],
-            get_sub2api_push_settings(),
+            self.get_sub2api_push_settings(),
         )
         self.assertEqual(email[:64], bundle["accounts"][0]["name"])
 
     def test_normalize_proxy_urls_preserves_commas_inside_userinfo(self):
         self.assertEqual(
             ["http://user:pa,ss@host.example:8080"],
-            normalize_sub2api_proxy_urls("http://user:pa,ss@host.example:8080"),
+            self.normalize_sub2api_proxy_urls("http://user:pa,ss@host.example:8080"),
         )
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -8,6 +8,7 @@ import shutil
 from datetime import datetime
 from typing import Optional
 from utils.proxy_manager import reload_proxy_config
+from utils.integrations.sub2api_proxy import get_valid_sub2api_proxy_urls
 
 CONFIG_FILE_LOCK = threading.Lock()
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -151,6 +152,7 @@ SUB2API_ACCOUNT_RATE_MULTIPLIER: float = 1.0
 SUB2API_ACCOUNT_GROUP_IDS: list = []
 SUB2API_ENABLE_WS_MODE: bool = True
 SUB2API_DEFAULT_PROXY: str = ""
+SUB2API_DEFAULT_PROXY_POOL: list = []
 
 LUCKMAIL_PREFERRED_DOMAIN: str = ""
 LUCKMAIL_EMAIL_TYPE: str = ""
@@ -202,6 +204,37 @@ TMAILOR_CURRENT_TOKEN: str = ""
 REG_MODE: str = "protocol"
 DB_TYPE: str = "sqlite"
 MYSQL_CFG: dict = {}
+_sub2api_proxy_rotation_lock = threading.Lock()
+_sub2api_proxy_rotation_index = 0
+
+
+def reset_sub2api_proxy_rotation():
+    global _sub2api_proxy_rotation_index
+    with _sub2api_proxy_rotation_lock:
+        _sub2api_proxy_rotation_index = 0
+
+
+def _resolve_sub2api_proxy_pool(raw_value=None):
+    if raw_value is None:
+        if SUB2API_DEFAULT_PROXY_POOL:
+            return list(SUB2API_DEFAULT_PROXY_POOL)
+        raw_items = get_valid_sub2api_proxy_urls(SUB2API_DEFAULT_PROXY)
+    else:
+        raw_items = get_valid_sub2api_proxy_urls(raw_value)
+    return [format_docker_url(item) for item in raw_items if item]
+
+
+def get_next_sub2api_proxy_url(raw_value=None) -> str:
+    global _sub2api_proxy_rotation_index
+
+    proxy_pool = _resolve_sub2api_proxy_pool(raw_value)
+    if not proxy_pool:
+        return ""
+
+    with _sub2api_proxy_rotation_lock:
+        current_index = _sub2api_proxy_rotation_index % len(proxy_pool)
+        _sub2api_proxy_rotation_index = (_sub2api_proxy_rotation_index + 1) % len(proxy_pool)
+    return proxy_pool[current_index]
 
 def reload_all_configs(new_config_dict=None):
     global _c
@@ -229,6 +262,7 @@ def reload_all_configs(new_config_dict=None):
     global SUB2API_SAVE_TO_LOCAL
     global SUB2API_REMOVE_ON_LIMIT_REACHED, SUB2API_REMOVE_DEAD_ACCOUNTS, SUB2API_ENABLE_TOKEN_REVIVE
     global SUB2API_ACCOUNT_CONCURRENCY, SUB2API_ACCOUNT_LOAD_FACTOR, SUB2API_ACCOUNT_PRIORITY, SUB2API_DEFAULT_PROXY
+    global SUB2API_DEFAULT_PROXY_POOL
     global SUB2API_ACCOUNT_RATE_MULTIPLIER, SUB2API_ACCOUNT_GROUP_IDS, SUB2API_ENABLE_WS_MODE
     global LUCKMAIL_API_KEY, LUCKMAIL_PREFERRED_DOMAIN, LUCKMAIL_EMAIL_TYPE, LUCKMAIL_VARIANT_MODE, LUCKMAIL_REUSE_PURCHASED, LUCKMAIL_TAG_ID
     global HERO_SMS_ENABLED, HERO_SMS_API_KEY, HERO_SMS_BASE_URL, HERO_SMS_COUNTRY, HERO_SMS_SERVICE
@@ -438,7 +472,16 @@ def reload_all_configs(new_config_dict=None):
     SUB2API_ACCOUNT_RATE_MULTIPLIER = safe_float(_sub2api.get("account_rate_multiplier", 1.0), 1.0, minimum=0.0)
     SUB2API_ACCOUNT_GROUP_IDS = parse_group_ids(_sub2api.get("account_group_ids", ""))
     SUB2API_ENABLE_WS_MODE = safe_bool(_sub2api.get("enable_ws_mode", True), default=True)
-    SUB2API_DEFAULT_PROXY = _sub2api.get("default_proxy", "")
+    raw_sub2api_default_proxy = _sub2api.get("default_proxy", "")
+    if isinstance(raw_sub2api_default_proxy, list):
+        SUB2API_DEFAULT_PROXY = "\n".join(str(item).strip() for item in raw_sub2api_default_proxy if str(item).strip())
+    else:
+        SUB2API_DEFAULT_PROXY = str(raw_sub2api_default_proxy or "")
+    SUB2API_DEFAULT_PROXY_POOL = [
+        format_docker_url(item)
+        for item in get_valid_sub2api_proxy_urls(raw_sub2api_default_proxy)
+    ]
+    reset_sub2api_proxy_rotation()
     _normal = _c.get("normal_mode", {})
     NORMAL_SLEEP_MIN = _normal.get("sleep_min", 5)
     NORMAL_SLEEP_MAX = _normal.get("sleep_max", 30)

--- a/utils/integrations/sub2api_client.py
+++ b/utils/integrations/sub2api_client.py
@@ -5,8 +5,103 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
 from utils import config as cfg
 from curl_cffi import requests as cffi_requests
+from utils.integrations.sub2api_proxy import parse_sub2api_proxy
 
 logger = logging.getLogger(__name__)
+
+
+def get_sub2api_push_settings() -> Dict[str, Any]:
+    def as_int(value: Any, default: int, minimum: int) -> int:
+        try:
+            return max(minimum, int(value))
+        except (TypeError, ValueError):
+            return default
+
+    def as_float(value: Any, default: float, minimum: float) -> float:
+        try:
+            return max(minimum, float(value))
+        except (TypeError, ValueError):
+            return default
+
+    raw_group_ids = getattr(cfg, "SUB2API_ACCOUNT_GROUP_IDS", [])
+    if isinstance(raw_group_ids, list):
+        group_ids = [int(item) for item in raw_group_ids if str(item).strip().isdigit()]
+    else:
+        group_ids = [int(item.strip()) for item in str(raw_group_ids or "").split(",") if item.strip().isdigit()]
+
+    return {
+        "concurrency": as_int(getattr(cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10), 10, 1),
+        "load_factor": as_int(getattr(cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10), 10, 1),
+        "priority": as_int(getattr(cfg, "SUB2API_ACCOUNT_PRIORITY", 1), 1, 1),
+        "rate_multiplier": as_float(getattr(cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0), 1.0, 0.0),
+        "group_ids": group_ids,
+        "enable_ws": bool(getattr(cfg, "SUB2API_ENABLE_WS_MODE", True)),
+    }
+
+
+def _build_account_extra(settings: Dict[str, Any]) -> Dict[str, Any]:
+    extra = {"load_factor": settings["load_factor"]}
+    if settings["enable_ws"]:
+        extra["openai_oauth_responses_websockets_v2_enabled"] = True
+        extra["openai_oauth_responses_websockets_v2_mode"] = "passthrough"
+    return extra
+
+
+def _build_account_item(token_data: Dict[str, Any], settings: Dict[str, Any], proxy_obj: Dict[str, Any] | None) -> Dict[str, Any]:
+    account_item = {
+        "name": str(token_data.get("email", "unknown"))[:64],
+        "platform": "openai",
+        "type": "oauth",
+        "credentials": {
+            "access_token": token_data.get("access_token", ""),
+            "chatgpt_account_id": token_data.get("account_id", ""),
+            "client_id": token_data.get("client_id", ""),
+            "expires_at": int(time.time() + 864000),
+            "expires_in": 863999,
+            "model_mapping": {
+                "gpt-4o": "gpt-4o",
+                "gpt-4": "gpt-4",
+                "gpt-3.5-turbo": "gpt-3.5-turbo",
+            },
+            "organization_id": token_data.get("workspace_id", ""),
+            "refresh_token": token_data.get("refresh_token", ""),
+        },
+        "extra": _build_account_extra(settings),
+        "concurrency": settings["concurrency"],
+        "priority": settings["priority"],
+        "rate_multiplier": settings["rate_multiplier"],
+        "auto_pause_on_expired": True,
+    }
+    if settings["group_ids"]:
+        account_item["group_ids"] = settings["group_ids"]
+    if proxy_obj and "proxy_key" in proxy_obj:
+        account_item["proxy_key"] = proxy_obj["proxy_key"]
+    return account_item
+
+
+def build_sub2api_export_bundle(
+    token_items: List[Dict[str, Any]],
+    settings: Dict[str, Any] | None = None,
+    *,
+    rotate_missing_proxy: bool = False,
+) -> Dict[str, Any]:
+    push_settings = settings or get_sub2api_push_settings()
+    proxies_by_key: Dict[str, Dict[str, Any]] = {}
+    accounts: List[Dict[str, Any]] = []
+
+    for token_data in token_items:
+        proxy_obj = token_data.get("sub2api_proxy")
+        if proxy_obj is None and rotate_missing_proxy:
+            proxy_obj = parse_sub2api_proxy(cfg.get_next_sub2api_proxy_url())
+        if proxy_obj and proxy_obj.get("proxy_key"):
+            proxies_by_key[proxy_obj["proxy_key"]] = proxy_obj
+        accounts.append(_build_account_item(token_data, push_settings, proxy_obj))
+
+    return {
+        "exported_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "proxies": list(proxies_by_key.values()),
+        "accounts": accounts,
+    }
 
 
 class Sub2APIClient:
@@ -43,45 +138,10 @@ class Sub2APIClient:
         return False, error_msg
 
     def _get_push_settings(self) -> Dict[str, Any]:
-        try:
-            import utils.config as cfg
-        except ImportError:
-            cfg = None
-
-        def as_int(value: Any, default: int, minimum: int) -> int:
-            try:
-                return max(minimum, int(value))
-            except (TypeError, ValueError):
-                return default
-        def as_float(value: Any, default: float, minimum: float) -> float:
-            try:
-                return max(minimum, float(value))
-            except (TypeError, ValueError):
-                return default
-
-        raw_group_ids = getattr(cfg, "SUB2API_ACCOUNT_GROUP_IDS", []) if cfg else []
-        if isinstance(raw_group_ids, list):
-            group_ids = [int(item) for item in raw_group_ids if str(item).strip().isdigit()]
-        else:
-            group_ids = [int(item.strip()) for item in str(raw_group_ids or "").split(",") if
-                         item.strip().isdigit()]
-
-        return {
-            "concurrency": as_int(getattr(cfg, "SUB2API_ACCOUNT_CONCURRENCY", 10) if cfg else 10, 10, 1),
-            "load_factor": as_int(getattr(cfg, "SUB2API_ACCOUNT_LOAD_FACTOR", 10) if cfg else 10, 10, 1),
-            "priority": as_int(getattr(cfg, "SUB2API_ACCOUNT_PRIORITY", 1) if cfg else 1, 1, 1),
-            "rate_multiplier": as_float(getattr(cfg, "SUB2API_ACCOUNT_RATE_MULTIPLIER", 1.0) if cfg else 1.0, 1.0,
-                                        0.0),
-            "group_ids": group_ids,
-            "enable_ws": bool(getattr(cfg, "SUB2API_ENABLE_WS_MODE", True) if cfg else True),
-        }
+        return get_sub2api_push_settings()
 
     def _build_account_extra(self, settings: Dict[str, Any]) -> Dict[str, Any]:
-        extra = {"load_factor": settings["load_factor"]}
-        if settings["enable_ws"]:
-            extra["openai_oauth_responses_websockets_v2_enabled"] = True
-            extra["openai_oauth_responses_websockets_v2_mode"] = "passthrough"
-        return extra
+        return _build_account_extra(settings)
 
     def _refresh_created_account(self, account_id: str) -> None:
         if not account_id:
@@ -112,45 +172,12 @@ class Sub2APIClient:
 
     def _import_account(self, token_data: Dict[str, Any], settings: Dict[str, Any]) -> Tuple[bool, str]:
         url = f"{self.api_url}/api/v1/admin/accounts/data"
-        exported_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        extra = self._build_account_extra(settings)
-        proxy_obj = token_data.get("sub2api_proxy")
-        account_item = {
-            "name": token_data.get("email", "unknown"),
-            "platform": "openai",
-            "type": "oauth",
-            "credentials": {
-                "access_token": token_data.get("access_token", ""),
-                "chatgpt_account_id": token_data.get("account_id", ""),
-                "client_id": token_data.get("client_id", ""),
-                "expires_at": int(time.time() + 864000),
-                "expires_in": 863999,
-                "model_mapping": {
-                    "gpt-4o": "gpt-4o",
-                    "gpt-4": "gpt-4",
-                    "gpt-3.5-turbo": "gpt-3.5-turbo",
-                },
-                "organization_id": token_data.get("workspace_id", ""),
-                "refresh_token": token_data.get("refresh_token", ""),
-            },
-            "extra": extra,
-            "concurrency": settings["concurrency"],
-            "priority": settings["priority"],
-            "rate_multiplier": settings["rate_multiplier"],
-            "auto_pause_on_expired": True,
-        }
-        if settings["group_ids"]:
-            account_item["group_ids"] = settings["group_ids"]
-
-        if proxy_obj and "proxy_key" in proxy_obj:
-            account_item["proxy_key"] = proxy_obj["proxy_key"]
+        bundle = build_sub2api_export_bundle([token_data], settings, rotate_missing_proxy=True)
         payload = {
             "data": {
                 "type": "sub2api-data",
                 "version": 1,
-                "exported_at": exported_at,
-                "proxies": [proxy_obj] if proxy_obj else [],
-                "accounts": [account_item],
+                **bundle,
             },
             "skip_default_group_bind": not bool(settings["group_ids"]),
         }
@@ -220,14 +247,19 @@ class Sub2APIClient:
 
     def add_account(self, token_data: Dict[str, Any]) -> Tuple[bool, str]:
         settings = self._get_push_settings()
-        refresh_token = token_data.get("refresh_token", "")
-        proxy_obj = token_data.get("sub2api_proxy")
+        working_token_data = dict(token_data)
+        refresh_token = working_token_data.get("refresh_token", "")
+        proxy_obj = working_token_data.get("sub2api_proxy")
+        if proxy_obj is None:
+            proxy_obj = parse_sub2api_proxy(cfg.get_next_sub2api_proxy_url())
+            if proxy_obj:
+                working_token_data["sub2api_proxy"] = proxy_obj
         if not refresh_token or proxy_obj:
-            return self._import_account(token_data, settings)
+            return self._import_account(working_token_data, settings)
 
         url = f"{self.api_url}/api/v1/admin/accounts"
         payload = {
-            "name": token_data.get("email", "unknown")[:64],
+            "name": working_token_data.get("email", "unknown")[:64],
             "platform": "openai",
             "type": "oauth",
             "credentials": {"refresh_token": refresh_token},
@@ -254,7 +286,7 @@ class Sub2APIClient:
             ok, result = self._handle_response(response, success_codes=(200, 201))
             if not ok:
                 logger.warning("Sub2API direct create failed, falling back to import endpoint: %s", result)
-                return self._import_account(token_data, settings)
+                return self._import_account(working_token_data, settings)
 
             account_id = result.get("data", {}).get("id") if isinstance(result, dict) else None
             if account_id:
@@ -262,7 +294,7 @@ class Sub2APIClient:
             return True, "Sub2API account created successfully"
         except Exception as exc:
             logger.warning("Sub2API direct create raised an exception, falling back to import: %s", exc)
-            return self._import_account(token_data, settings)
+            return self._import_account(working_token_data, settings)
 
     def update_account(self, account_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Any]:
         url = f"{self.api_url}/api/v1/admin/accounts/{account_id}"

--- a/utils/integrations/sub2api_proxy.py
+++ b/utils/integrations/sub2api_proxy.py
@@ -1,0 +1,61 @@
+from urllib.parse import urlparse
+from typing import Any, Dict, List, Optional
+
+
+def normalize_sub2api_proxy_urls(raw_value: Any) -> List[str]:
+    if isinstance(raw_value, list):
+        raw_items = raw_value
+    else:
+        text = str(raw_value or "").replace("\r", "\n")
+        raw_items = text.split("\n")
+
+    proxy_urls: List[str] = []
+    seen = set()
+    for item in raw_items:
+        value = str(item or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        proxy_urls.append(value)
+    return proxy_urls
+
+
+def parse_sub2api_proxy(proxy_url: str) -> Optional[Dict[str, Any]]:
+    if not proxy_url:
+        return None
+
+    try:
+        parsed = urlparse(str(proxy_url).strip())
+        protocol = parsed.scheme
+        host = parsed.hostname
+        port = parsed.port
+        username = parsed.username or ""
+        password = parsed.password or ""
+
+        if not protocol or not host or not port:
+            return None
+
+        proxy_key = f"{protocol}|{host}|{port}|{username}|{password}"
+        proxy_dict: Dict[str, Any] = {
+            "proxy_key": proxy_key,
+            "name": "openai-cpa",
+            "protocol": protocol,
+            "host": host,
+            "port": port,
+            "status": "active",
+        }
+        if username and password:
+            proxy_dict["username"] = username
+            proxy_dict["password"] = password
+        return proxy_dict
+    except Exception:
+        return None
+
+
+def get_valid_sub2api_proxy_urls(raw_value: Any) -> List[str]:
+    proxy_urls: List[str] = []
+    for item in normalize_sub2api_proxy_urls(raw_value):
+        if parse_sub2api_proxy(item) is None:
+            continue
+        proxy_urls.append(item)
+    return proxy_urls


### PR DESCRIPTION
Summary

This PR adds a Sub2API-only proxy pool for auth push and export flows.

Proxy-attached Sub2API auth pushes now use the `/api/v1/admin/accounts/data` import endpoint so proxy definitions and auth credentials can be submitted together.
When no proxy is configured, the original direct-create path is preserved.
Closes #43.

The branch is intentionally named `issue43-sub2api-proxy-pool` without any `codex/` prefix, per request.

Changes

- add a multiline Sub2API proxy pool input
- add `0 / 1 / 2+` proxy pool behavior for Sub2API
- reuse the same proxy rotation logic across push, auto replenish, and export
- filter invalid proxies and support legacy string/list config values
- add minimal tests for rotation and edge cases

Test

python -m unittest tests\test_sub2api_proxy_pool.py
python -m py_compile utils\config.py utils\integrations\sub2api_proxy.py utils\integrations\sub2api_client.py routers\api_routes.py tests\test_sub2api_proxy_pool.py