### PR TITLE
Fix memory leak and memory pressure patterns causing OOM

### DIFF
--- a/global_state.py
+++ b/global_state.py
@@ -8,16 +8,19 @@ VALID_TOKENS = set()
 CLUSTER_NODES = {}
 NODE_COMMANDS = {}
 cluster_lock = threading.Lock()
-log_history = []
+log_history = deque(maxlen=500)
 worker_status: dict = {}
 engine = core_engine.RegEngine()
 
 
 def append_log(msg: str):
     log_history.append(msg)
-    limit = getattr(cfg, 'MAX_LOG_LINES', 500)
-    if len(log_history) > limit * 1.2:
-        del log_history[:-limit]
+
+
+def update_log_maxlen(new_limit: int):
+    global log_history
+    if new_limit != log_history.maxlen:
+        log_history = deque(log_history, maxlen=new_limit)
 
 async def verify_token(authorization: str = Header(None)):
     if not authorization or not authorization.startswith("Bearer "):

--- a/global_state.py
+++ b/global_state.py
@@ -8,7 +8,7 @@ VALID_TOKENS = set()
 CLUSTER_NODES = {}
 NODE_COMMANDS = {}
 cluster_lock = threading.Lock()
-log_history = deque(maxlen=500)
+log_history = deque(maxlen=cfg.MAX_LOG_LINES)
 worker_status: dict = {}
 engine = core_engine.RegEngine()
 
@@ -16,11 +16,6 @@ engine = core_engine.RegEngine()
 def append_log(msg: str):
     log_history.append(msg)
 
-
-def update_log_maxlen(new_limit: int):
-    global log_history
-    if new_limit != log_history.maxlen:
-        log_history = deque(log_history, maxlen=new_limit)
 
 async def verify_token(authorization: str = Header(None)):
     if not authorization or not authorization.startswith("Bearer "):

--- a/routers/api_routes.py
+++ b/routers/api_routes.py
@@ -22,7 +22,7 @@ from utils.integrations.sub2api_client import Sub2APIClient
 from utils.integrations.tg_notifier import send_tg_msg_async
 from utils.email_providers.gmail_oauth_handler import GmailOAuthHandler
 from curl_cffi import requests as cffi_requests
-from global_state import VALID_TOKENS, CLUSTER_NODES, NODE_COMMANDS, cluster_lock, log_history, engine, verify_token, worker_status
+from global_state import VALID_TOKENS, CLUSTER_NODES, NODE_COMMANDS, cluster_lock, log_history, engine, verify_token, worker_status, append_log
 import utils.config as cfg
 import utils.integrations.clash_manager as clash_manager
 router = APIRouter()
@@ -911,7 +911,7 @@ def cluster_upload_accounts(req: ClusterUploadAccountsReq):
     msg = f"[{core_engine.ts()}] [系统] 📦 成功从子控 [{req.node_name}] 提取并完美入库 {success_count} 个账号！"
     print(msg)
     try:
-        log_history.append(msg)
+        append_log(msg)
     except:
         pass
     return {"status": "success", "message": f"成功接收 {success_count} 个账号"}

--- a/tests/test_log_stream_cache.py
+++ b/tests/test_log_stream_cache.py
@@ -1,0 +1,66 @@
+import unittest
+
+from utils.log_stream_cache import RecentParsedLogCache
+
+
+class RecentParsedLogCacheTests(unittest.TestCase):
+    def test_reuses_parsed_logs_when_recent_window_is_unchanged(self):
+        cache = RecentParsedLogCache(limit=3)
+        logs = [
+            "[10:00:00] [info] first",
+            "[10:00:01] [warning] second",
+        ]
+
+        first_recent, first_parsed, changed = cache.refresh(logs)
+        self.assertTrue(changed)
+        self.assertEqual(first_recent, logs)
+        self.assertEqual(len(first_parsed), 2)
+
+        second_recent, second_parsed, changed = cache.refresh(list(logs))
+        self.assertFalse(changed)
+        self.assertEqual(second_recent, logs)
+        self.assertIs(second_parsed, first_parsed)
+
+    def test_only_parses_new_entries_when_window_grows(self):
+        cache = RecentParsedLogCache(limit=3)
+        initial_logs = [
+            "[10:00:00] [info] first",
+            "[10:00:01] [warning] second",
+        ]
+
+        _, first_parsed, _ = cache.refresh(initial_logs)
+        updated_logs = initial_logs + ["[10:00:02] [error] third"]
+
+        recent, second_parsed, changed = cache.refresh(updated_logs)
+
+        self.assertTrue(changed)
+        self.assertEqual(recent, updated_logs[-3:])
+        self.assertEqual(len(second_parsed), 3)
+        self.assertIs(second_parsed[0], first_parsed[0])
+        self.assertIs(second_parsed[1], first_parsed[1])
+        self.assertEqual(second_parsed[2]["level"], "ERROR")
+        self.assertEqual(second_parsed[2]["text"], "third")
+
+    def test_reuses_overlap_when_recent_window_slides(self):
+        cache = RecentParsedLogCache(limit=3)
+        initial_logs = [
+            "[10:00:00] [info] first",
+            "[10:00:01] [warning] second",
+            "[10:00:02] [error] third",
+        ]
+
+        _, first_parsed, _ = cache.refresh(initial_logs)
+        updated_logs = initial_logs + ["[10:00:03] [info] fourth"]
+
+        recent, second_parsed, changed = cache.refresh(updated_logs)
+
+        self.assertTrue(changed)
+        self.assertEqual(recent, updated_logs[-3:])
+        self.assertEqual(len(second_parsed), 3)
+        self.assertIs(second_parsed[0], first_parsed[1])
+        self.assertIs(second_parsed[1], first_parsed[2])
+        self.assertEqual(second_parsed[2]["text"], "fourth")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reg_engine_executor_cleanup.py
+++ b/tests/test_reg_engine_executor_cleanup.py
@@ -41,6 +41,20 @@ from utils.core_engine import RegEngine
 
 
 class RegEngineExecutorCleanupTests(unittest.TestCase):
+    def test_start_normal_reclaims_executor_after_natural_completion(self):
+        engine = RegEngine()
+        executor = Mock()
+        engine._executor = executor
+        args = SimpleNamespace()
+
+        with patch("utils.core_engine.normal_main_loop", side_effect=lambda *a, **kw: None):
+            engine.start_normal(args)
+            engine.current_thread.join(timeout=2)
+
+        self.assertFalse(engine.current_thread.is_alive())
+        executor.shutdown.assert_called_once_with(wait=False)
+        self.assertIsNone(engine._executor)
+
     def test_run_threads_reclaim_executor_after_natural_completion(self):
         cases = [
             ("_run_cpa_in_thread", "_cpa_wrapper"),

--- a/tests/test_reg_engine_executor_cleanup.py
+++ b/tests/test_reg_engine_executor_cleanup.py
@@ -4,38 +4,38 @@ import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
-if "curl_cffi" not in sys.modules:
-    sys.modules["curl_cffi"] = types.SimpleNamespace(
+# Stub heavy third-party and project dependencies so we can import
+# RegEngine without installing the full runtime stack.
+_stubs = {
+    "yaml": types.SimpleNamespace(
+        safe_load=lambda *a, **kw: {},
+        safe_dump=lambda *a, **kw: "",
+    ),
+    "curl_cffi": types.SimpleNamespace(
         requests=types.SimpleNamespace(),
         CurlMime=object,
-    )
-
-if "utils.email_providers.mail_service" not in sys.modules:
-    sys.modules["utils.email_providers.mail_service"] = types.SimpleNamespace(
+    ),
+    "utils.email_providers.mail_service": types.SimpleNamespace(
         mask_email=lambda value: value,
-    )
-
-if "utils.register" not in sys.modules:
-    sys.modules["utils.register"] = types.SimpleNamespace(
+    ),
+    "utils.register": types.SimpleNamespace(
         run=lambda *args, **kwargs: None,
         refresh_oauth_token=lambda *args, **kwargs: (False, {}),
-    )
-
-if "utils.proxy_manager" not in sys.modules:
-    sys.modules["utils.proxy_manager"] = types.SimpleNamespace(
+    ),
+    "utils.proxy_manager": types.SimpleNamespace(
         smart_switch_node=lambda *args, **kwargs: True,
         reload_proxy_config=lambda *args, **kwargs: None,
-    )
-
-if "utils.integrations.sub2api_client" not in sys.modules:
-    sys.modules["utils.integrations.sub2api_client"] = types.SimpleNamespace(
+    ),
+    "utils.integrations.sub2api_client": types.SimpleNamespace(
         Sub2APIClient=object,
-    )
-
-if "utils.integrations.tg_notifier" not in sys.modules:
-    sys.modules["utils.integrations.tg_notifier"] = types.SimpleNamespace(
+    ),
+    "utils.integrations.tg_notifier": types.SimpleNamespace(
         send_tg_msg_sync=lambda *args, **kwargs: None,
-    )
+    ),
+}
+for mod_name, stub in _stubs.items():
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = stub
 
 from utils.core_engine import RegEngine
 

--- a/tests/test_reg_engine_executor_cleanup.py
+++ b/tests/test_reg_engine_executor_cleanup.py
@@ -1,0 +1,70 @@
+import unittest
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+if "curl_cffi" not in sys.modules:
+    sys.modules["curl_cffi"] = types.SimpleNamespace(
+        requests=types.SimpleNamespace(),
+        CurlMime=object,
+    )
+
+if "utils.email_providers.mail_service" not in sys.modules:
+    sys.modules["utils.email_providers.mail_service"] = types.SimpleNamespace(
+        mask_email=lambda value: value,
+    )
+
+if "utils.register" not in sys.modules:
+    sys.modules["utils.register"] = types.SimpleNamespace(
+        run=lambda *args, **kwargs: None,
+        refresh_oauth_token=lambda *args, **kwargs: (False, {}),
+    )
+
+if "utils.proxy_manager" not in sys.modules:
+    sys.modules["utils.proxy_manager"] = types.SimpleNamespace(
+        smart_switch_node=lambda *args, **kwargs: True,
+        reload_proxy_config=lambda *args, **kwargs: None,
+    )
+
+if "utils.integrations.sub2api_client" not in sys.modules:
+    sys.modules["utils.integrations.sub2api_client"] = types.SimpleNamespace(
+        Sub2APIClient=object,
+    )
+
+if "utils.integrations.tg_notifier" not in sys.modules:
+    sys.modules["utils.integrations.tg_notifier"] = types.SimpleNamespace(
+        send_tg_msg_sync=lambda *args, **kwargs: None,
+    )
+
+from utils.core_engine import RegEngine
+
+
+class RegEngineExecutorCleanupTests(unittest.TestCase):
+    def test_run_threads_reclaim_executor_after_natural_completion(self):
+        cases = [
+            ("_run_cpa_in_thread", "_cpa_wrapper"),
+            ("_run_sub2api_in_thread", "sub2api_main_loop"),
+            ("_run_check_in_thread", "manual_check_main_loop"),
+        ]
+
+        for runner_name, target_name in cases:
+            with self.subTest(runner=runner_name):
+                engine = RegEngine()
+                executor = Mock()
+                engine._executor = executor
+                args = SimpleNamespace()
+
+                if target_name.startswith("_"):
+                    setattr(engine, target_name, AsyncMock(return_value=None))
+                    getattr(engine, runner_name)(args)
+                else:
+                    with patch(f"utils.core_engine.{target_name}", new=AsyncMock(return_value=None)):
+                        getattr(engine, runner_name)(args)
+
+                executor.shutdown.assert_called_once_with(wait=False)
+                self.assertIsNone(engine._executor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -554,7 +554,6 @@ def reload_all_configs(new_config_dict=None):
 
     MAX_LOG_LINES = safe_int(_c.get("max_log_lines", 500), 500, minimum=50)
 
-
     reload_proxy_config()
     print(f"[{ts()}] [系统] 核心配置已完成同步。")
 

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -840,7 +840,7 @@ def process_sub2api_worker(i: int, total: int, item: dict, client: Any, args: An
     _handle_sub2api_dead_account(item, client, is_disabled=False)
     return False
 
-def normal_main_loop(args, stop_event: threading.Event):
+def normal_main_loop(args, stop_event: threading.Event, executor=None):
     """常规量产模式（纯数据库保存）"""
     sleep_min    = max(1, cfg.NORMAL_SLEEP_MIN)
     sleep_max    = max(sleep_min, cfg.NORMAL_SLEEP_MAX)
@@ -889,11 +889,17 @@ def normal_main_loop(args, stop_event: threading.Event):
                             cfg.PROXY_QUEUE.task_done()
                     return run_and_refresh(args.proxy, args, False, skip_switch=True)
 
-                with ThreadPoolExecutor(max_workers=current_batch) as ex:
-                    futures = [ex.submit(_worker) for _ in range(current_batch)]
+                if executor is not None:
+                    futures = [executor.submit(_worker) for _ in range(current_batch)]
                     for f in futures:
                         if f.result() == "success":
                             success_count += 1
+                else:
+                    with ThreadPoolExecutor(max_workers=current_batch) as ex:
+                        futures = [ex.submit(_worker) for _ in range(current_batch)]
+                        for f in futures:
+                            if f.result() == "success":
+                                success_count += 1
             else:
                 if cfg._clash_enable and cfg._clash_pool_mode:
                     p = cfg.PROXY_QUEUE.get()
@@ -924,7 +930,7 @@ def normal_main_loop(args, stop_event: threading.Event):
             break
 
 
-async def perform_cpa_check(args, async_stop_event, loop):
+async def perform_cpa_check(args, async_stop_event, loop, executor=None):
     print(f"[{ts()}] [INFO] 开始执行 CPA 仓库全量测活巡检...")
     res = requests.get(
         _normalize_cpa_auth_files_url(cfg.CPA_API_URL),
@@ -939,19 +945,26 @@ async def perform_cpa_check(args, async_stop_event, loop):
     ]
     total_files = len(codex_files)
 
-    with ThreadPoolExecutor(max_workers=cfg.CPA_THREADS) as executor:
+    if executor is not None:
         futures = [
             loop.run_in_executor(executor, process_account_worker, i, total_files, item, args)
             for i, item in enumerate(codex_files, 1)
         ]
         results = await asyncio.gather(*futures)
+    else:
+        with ThreadPoolExecutor(max_workers=cfg.CPA_THREADS) as _ex:
+            futures = [
+                loop.run_in_executor(_ex, process_account_worker, i, total_files, item, args)
+                for i, item in enumerate(codex_files, 1)
+            ]
+            results = await asyncio.gather(*futures)
 
     valid_count = sum(1 for r in results if r)
     print(f"[{ts()}] [INFO] CPA 测活结束，当前有效数: {valid_count} / {total_files}")
     return valid_count, total_files
 
 
-async def perform_sub2api_check(args, async_stop_event, loop, client):
+async def perform_sub2api_check(args, async_stop_event, loop, client, executor=None):
     print(f"[{ts()}] [INFO] 开始执行 Sub2API 仓库全量测活巡检...")
     success, account_list = client.get_all_accounts()
     if not success:
@@ -960,28 +973,35 @@ async def perform_sub2api_check(args, async_stop_event, loop, client):
 
     total_files = len(account_list)
 
-    with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as executor:
+    if executor is not None:
         futures = [
             loop.run_in_executor(executor, process_sub2api_worker, i, total_files, item, client, args)
             for i, item in enumerate(account_list, 1)
         ]
         results = await asyncio.gather(*futures)
+    else:
+        with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as _ex:
+            futures = [
+                loop.run_in_executor(_ex, process_sub2api_worker, i, total_files, item, client, args)
+                for i, item in enumerate(account_list, 1)
+            ]
+            results = await asyncio.gather(*futures)
 
     valid_count = sum(1 for r in results if r)
     print(f"[{ts()}] [INFO] Sub2API 测活结束，当前有效数: {valid_count} / {total_files}")
     return valid_count, total_files
 
-async def manual_check_main_loop(args, async_stop_event: asyncio.Event):
+async def manual_check_main_loop(args, async_stop_event: asyncio.Event, executor=None):
     print("=" * 60)
     print(f"\n[{ts()}] [系统] >>> 启动独立测活清理任务 <<<")
     print("=" * 60)
     loop = asyncio.get_running_loop()
 
     if cfg.ENABLE_CPA_MODE:
-        await perform_cpa_check(args, async_stop_event, loop)
+        await perform_cpa_check(args, async_stop_event, loop, executor=executor)
     elif cfg.ENABLE_SUB2API_MODE:
         client = Sub2APIClient(api_url=cfg.SUB2API_URL, api_key=cfg.SUB2API_KEY)
-        await perform_sub2api_check(args, async_stop_event, loop, client)
+        await perform_sub2api_check(args, async_stop_event, loop, client, executor=executor)
     else:
         print(f"[{ts()}] [WARNING] 当前未开启 CPA 或 Sub2API 模式，无法执行仓管测活。")
 
@@ -990,7 +1010,7 @@ async def manual_check_main_loop(args, async_stop_event: asyncio.Event):
     async_stop_event.set()
 
 
-async def cpa_main_loop(args, async_stop_event: asyncio.Event):
+async def cpa_main_loop(args, async_stop_event: asyncio.Event, executor=None):
     """CPA 智能仓管模式（接入发牌器，防止撞车）。"""
     print("=" * 60)
     print(f"\n[{ts()}] [系统] 目标库存阈值: {cfg.MIN_ACCOUNTS_THRESHOLD} | 单次补发量: {cfg.BATCH_REG_COUNT}")
@@ -1006,7 +1026,7 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event):
     while not async_stop_event.is_set() and not cfg.POOL_EXHAUSTED:
         try:
             if cfg.CPA_AUTO_CHECK:
-                valid_count, total_files = await perform_cpa_check(args, async_stop_event, loop)
+                valid_count, total_files = await perform_cpa_check(args, async_stop_event, loop, executor=executor)
             else:
                 print(f"\n[{ts()}] [INFO] 自动测活已关闭，直接读取云端列表进行补发判断...")
                 res = requests.get(
@@ -1055,12 +1075,19 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event):
                     if cfg.ENABLE_MULTI_THREAD_REG:
                         print(f"[{ts()}] [INFO] 多线程补货: {success_in_this_cycle}/{need_to_reg} "
                               f"({batch_size} 线程)")
-                        with ThreadPoolExecutor(max_workers=batch_size) as ex:
+                        if executor is not None:
                             reg_futures = [
-                                loop.run_in_executor(ex, _cpa_worker)
+                                loop.run_in_executor(executor, _cpa_worker)
                                 for _ in range(batch_size)
                             ]
                             reg_results = await asyncio.gather(*reg_futures)
+                        else:
+                            with ThreadPoolExecutor(max_workers=batch_size) as ex:
+                                reg_futures = [
+                                    loop.run_in_executor(ex, _cpa_worker)
+                                    for _ in range(batch_size)
+                                ]
+                                reg_results = await asyncio.gather(*reg_futures)
                         for status in reg_results:
                             if status == "success":
                                 success_in_this_cycle += 1
@@ -1110,7 +1137,7 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event):
             except asyncio.TimeoutError:
                 pass
 
-async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
+async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None):
     """Sub2API 智能仓管模式"""
     print("=" * 60)
     print(f"\n[{ts()}] [系统] Sub2API 目标库存阈值: {cfg.SUB2API_MIN_THRESHOLD} | 单次补发量: {cfg.SUB2API_BATCH_COUNT}")
@@ -1134,12 +1161,19 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
 
                 total_files = len(account_list)
 
-                with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as executor:
+                if executor is not None:
                     futures = [
                         loop.run_in_executor(executor, process_sub2api_worker, i, total_files, item, client, args)
                         for i, item in enumerate(account_list, 1)
                     ]
                     results = await asyncio.gather(*futures)
+                else:
+                    with ThreadPoolExecutor(max_workers=cfg.SUB2API_THREADS) as _ex:
+                        futures = [
+                            loop.run_in_executor(_ex, process_sub2api_worker, i, total_files, item, client, args)
+                            for i, item in enumerate(account_list, 1)
+                        ]
+                        results = await asyncio.gather(*futures)
 
                 valid_count = sum(1 for r in results if r)
                 print(f"[{ts()}] [INFO] 巡检结束，当前 Sub2API 仓库有效数: {valid_count}")
@@ -1205,12 +1239,19 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event):
                     if cfg.ENABLE_MULTI_THREAD_REG:
                         print(f"[{ts()}] [INFO] 多线程补货: {success_in_this_cycle}/{need_to_reg} "
                               f"({batch_size} 线程)")
-                        with ThreadPoolExecutor(max_workers=batch_size) as ex:
+                        if executor is not None:
                             reg_futures = [
-                                loop.run_in_executor(ex, _sub2api_worker)
+                                loop.run_in_executor(executor, _sub2api_worker)
                                 for _ in range(batch_size)
                             ]
                             reg_results = await asyncio.gather(*reg_futures)
+                        else:
+                            with ThreadPoolExecutor(max_workers=batch_size) as ex:
+                                reg_futures = [
+                                    loop.run_in_executor(ex, _sub2api_worker)
+                                    for _ in range(batch_size)
+                                ]
+                                reg_results = await asyncio.gather(*reg_futures)
 
                         for status in reg_results:
                             if status == "success":
@@ -1301,6 +1342,18 @@ class RegEngine:
         self.current_thread    = None
         self.loop              = None
         self._force_stopped    = False
+        self._executor         = None
+
+    def _ensure_executor(self, max_workers=None):
+        if self._executor is None:
+            workers = max_workers or max(cfg.REG_THREADS, getattr(cfg, 'CPA_THREADS', 4), getattr(cfg, 'SUB2API_THREADS', 4))
+            self._executor = ThreadPoolExecutor(max_workers=workers)
+        return self._executor
+
+    def _shutdown_executor(self):
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None
 
     def start_normal(self, args):
         if self.is_running():
@@ -1310,9 +1363,11 @@ class RegEngine:
         cfg.POOL_EXHAUSTED = False
         self.thread_stop_event.clear()
         args.check_stop = lambda: self.thread_stop_event.is_set()
+        self._ensure_executor()
         self.current_thread = threading.Thread(
             target=normal_main_loop,
             args=(args, self.thread_stop_event),
+            kwargs={"executor": self._executor},
             daemon=True,
         )
         self.current_thread.start()
@@ -1324,6 +1379,7 @@ class RegEngine:
         cfg.GLOBAL_STOP = False
         cfg.POOL_EXHAUSTED = False
         self.thread_stop_event.clear()
+        self._ensure_executor()
         self.current_thread = threading.Thread(
             target=self._run_cpa_in_thread, args=(args,), daemon=True
         )
@@ -1336,6 +1392,7 @@ class RegEngine:
         cfg.GLOBAL_STOP = False
         cfg.POOL_EXHAUSTED = False
         self.thread_stop_event.clear()
+        self._ensure_executor()
         self.current_thread = threading.Thread(
             target=self._run_sub2api_in_thread, args=(args,), daemon=True
         )
@@ -1354,13 +1411,13 @@ class RegEngine:
         asyncio.set_event_loop(self.loop)
         try:
             self.async_stop_event = asyncio.Event()
-            self.loop.run_until_complete(sub2api_main_loop(args, self.async_stop_event))
+            self.loop.run_until_complete(sub2api_main_loop(args, self.async_stop_event, executor=self._executor))
         finally:
             self.loop.close()
             
     async def _cpa_wrapper(self, args):
         self.async_stop_event = asyncio.Event()
-        await cpa_main_loop(args, self.async_stop_event)
+        await cpa_main_loop(args, self.async_stop_event, executor=self._executor)
 
     def stop(self):
         self._force_stopped = True
@@ -1369,6 +1426,8 @@ class RegEngine:
         self.thread_stop_event.set()
         if self.loop and self.async_stop_event:
             self.loop.call_soon_threadsafe(self.async_stop_event.set)
+
+        self._shutdown_executor()
 
         try:
             from utils.email_providers.postman_center import global_postman_fleet
@@ -1387,6 +1446,7 @@ class RegEngine:
         cfg.GLOBAL_STOP = False
         cfg.POOL_EXHAUSTED = False
         self.thread_stop_event.clear()
+        self._ensure_executor()
         self.current_thread = threading.Thread(
             target=self._run_check_in_thread, args=(args,), daemon=True
         )
@@ -1397,7 +1457,7 @@ class RegEngine:
         asyncio.set_event_loop(self.loop)
         try:
             self.async_stop_event = asyncio.Event()
-            self.loop.run_until_complete(manual_check_main_loop(args, self.async_stop_event))
+            self.loop.run_until_complete(manual_check_main_loop(args, self.async_stop_event, executor=self._executor))
         finally:
             self.loop.close()
             self._force_stopped = True

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -1372,9 +1372,8 @@ class RegEngine:
         args.check_stop = lambda: self.thread_stop_event.is_set()
         self._ensure_executor()
         self.current_thread = threading.Thread(
-            target=normal_main_loop,
-            args=(args, self.thread_stop_event),
-            kwargs={"executor": self._executor},
+            target=self._run_normal_in_thread,
+            args=(args,),
             daemon=True,
         )
         self.current_thread.start()
@@ -1410,6 +1409,12 @@ class RegEngine:
         asyncio.set_event_loop(self.loop)
         try:
             self.loop.run_until_complete(self._cpa_wrapper(args))
+        finally:
+            self._finalize_thread_run()
+
+    def _run_normal_in_thread(self, args):
+        try:
+            normal_main_loop(args, self.thread_stop_event, executor=self._executor)
         finally:
             self._finalize_thread_run()
 

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -1355,6 +1355,13 @@ class RegEngine:
             self._executor.shutdown(wait=False)
             self._executor = None
 
+    def _finalize_thread_run(self):
+        if self.loop is not None:
+            self.loop.close()
+            self.loop = None
+        self.async_stop_event = None
+        self._shutdown_executor()
+
     def start_normal(self, args):
         if self.is_running():
             return
@@ -1404,7 +1411,7 @@ class RegEngine:
         try:
             self.loop.run_until_complete(self._cpa_wrapper(args))
         finally:
-            self.loop.close()
+            self._finalize_thread_run()
 
     def _run_sub2api_in_thread(self, args):
         self.loop = asyncio.new_event_loop()
@@ -1413,7 +1420,7 @@ class RegEngine:
             self.async_stop_event = asyncio.Event()
             self.loop.run_until_complete(sub2api_main_loop(args, self.async_stop_event, executor=self._executor))
         finally:
-            self.loop.close()
+            self._finalize_thread_run()
             
     async def _cpa_wrapper(self, args):
         self.async_stop_event = asyncio.Event()
@@ -1459,7 +1466,7 @@ class RegEngine:
             self.async_stop_event = asyncio.Event()
             self.loop.run_until_complete(manual_check_main_loop(args, self.async_stop_event, executor=self._executor))
         finally:
-            self.loop.close()
+            self._finalize_thread_run()
             self._force_stopped = True
 
 if __name__ == "__main__":

--- a/utils/log_stream_cache.py
+++ b/utils/log_stream_cache.py
@@ -1,0 +1,59 @@
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+
+_LOG_PATTERN = re.compile(r"^\[(.*?)\]\s*\[(.*?)\]\s+(.*)$")
+
+
+def get_recent_logs(log_source: Iterable[str], limit: int) -> List[str]:
+    if limit <= 0:
+        return []
+    recent = list(log_source)
+    if len(recent) > limit:
+        return recent[-limit:]
+    return recent
+
+
+def parse_log_entry(raw: str) -> dict:
+    match = _LOG_PATTERN.match(raw.strip())
+    if match:
+        return {
+            "parsed": True,
+            "time": match.group(1),
+            "level": match.group(2).upper(),
+            "text": match.group(3),
+            "raw": raw,
+        }
+    return {"parsed": False, "raw": raw}
+
+
+class RecentParsedLogCache:
+    def __init__(self, limit: int = 50):
+        self.limit = max(1, int(limit))
+        self._recent_raw: List[str] = []
+        self._parsed_logs: List[dict] = []
+
+    def refresh(self, log_source: Iterable[str]) -> Tuple[List[str], List[dict], bool]:
+        recent = get_recent_logs(log_source, self.limit)
+        if recent == self._recent_raw:
+            return self._recent_raw, self._parsed_logs, False
+
+        overlap = self._find_overlap(recent)
+        if overlap > 0:
+            reused_start = len(self._recent_raw) - overlap
+            parsed = self._parsed_logs[reused_start:] + [
+                parse_log_entry(raw) for raw in recent[overlap:]
+            ]
+        else:
+            parsed = [parse_log_entry(raw) for raw in recent]
+
+        self._recent_raw = recent
+        self._parsed_logs = parsed
+        return self._recent_raw, self._parsed_logs, True
+
+    def _find_overlap(self, recent: Sequence[str]) -> int:
+        max_overlap = min(len(self._recent_raw), len(recent))
+        for overlap in range(max_overlap, 0, -1):
+            if self._recent_raw[-overlap:] == list(recent[:overlap]):
+                return overlap
+        return 0

--- a/utils/register.py
+++ b/utils/register.py
@@ -441,6 +441,11 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
         MAX_REG_RETRIES = 2
 
         for attempt in range(MAX_REG_RETRIES):
+            if active_sessions:
+                try:
+                    active_sessions[-1].close()
+                except Exception:
+                    pass
             s_reg = requests.Session(proxies=proxies, impersonate="chrome110")
             s_reg.headers.update({"Connection": "close"})
             s_reg.timeout = 30
@@ -895,6 +900,11 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
                 for oauth_attempt in range(2):
                     if oauth_attempt == 1:
                         print(f"[{cfg.ts()}] [ERROR] （{mask_email(email)}）首次遇到 add-phone 风控，正在重试...")
+                    if active_sessions:
+                        try:
+                            active_sessions[-1].close()
+                        except Exception:
+                            pass
                     s_log = requests.Session(proxies=proxies, impersonate="chrome110")
                     s_log.headers.update({"Connection": "close"})
                     s_log.timeout = 30

--- a/utils/register.py
+++ b/utils/register.py
@@ -1,4 +1,5 @@
 import base64
+import gc
 import hashlib
 import json
 import os
@@ -1310,7 +1311,8 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
                 s.close()
             except:
                 pass
-        active_sessions.clear()
+        del active_sessions[:]
+        gc.collect()
 
 def refresh_oauth_token(refresh_token: str, proxies: Any = None) -> Tuple[bool, dict]:
     if not refresh_token:

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -10,6 +10,7 @@ import warnings
 import subprocess
 import socket
 import socks
+import itertools
 warnings.filterwarnings("ignore", category=RuntimeWarning, module="trio")
 
 from fastapi import FastAPI
@@ -20,7 +21,7 @@ from contextlib import asynccontextmanager
 from utils import core_engine, db_manager
 from utils.config import reload_all_configs
 
-from global_state import engine, log_history
+from global_state import engine, log_history, append_log
 from routers import api_routes
 
 @asynccontextmanager
@@ -80,7 +81,7 @@ def _worker_push_thread():
             try:
                 while not core_engine.log_queue.empty():
                     msg = core_engine.log_queue.get_nowait()
-                    log_history.append(msg)
+                    append_log(msg)
             except: pass
 
             cf_dict = getattr(core_engine.cfg, '_c', {})
@@ -110,7 +111,7 @@ def _worker_push_thread():
                             try:
                                 while not core_engine.log_queue.empty():
                                     msg = core_engine.log_queue.get_nowait()
-                                    log_history.append(msg)
+                                    append_log(msg)
                             except: pass
 
                             s = core_engine.run_stats
@@ -134,7 +135,8 @@ def _worker_push_thread():
                             }
 
                             parsed_logs = []
-                            for raw in list(log_history)[-50:]:
+                            recent = list(itertools.islice(log_history, max(0, len(log_history) - 50), len(log_history)))
+                            for raw in recent:
                                 m = re.match(r"^\[(.*?)\]\s*\[(.*?)\]\s+(.*)$", raw.strip())
                                 if m: parsed_logs.append({"parsed": True, "time": m.group(1), "level": m.group(2).upper(), "text": m.group(3), "raw": raw})
                                 else: parsed_logs.append({"parsed": False, "raw": raw})

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -5,7 +5,6 @@ import time
 import asyncio
 import threading
 import uvicorn
-import re
 import warnings
 import subprocess
 import socket
@@ -19,6 +18,7 @@ from contextlib import asynccontextmanager
 
 from utils import core_engine, db_manager
 from utils.config import reload_all_configs
+from utils.log_stream_cache import RecentParsedLogCache
 
 from global_state import engine, log_history, append_log
 from routers import api_routes
@@ -59,6 +59,8 @@ class DummyArgs:
 
 def _worker_push_thread():
     last_role = None
+    log_cache = RecentParsedLogCache(limit=50)
+    push_interval = 1.0
 
     def _internal_start():
         try: reload_all_configs()
@@ -133,14 +135,12 @@ def _worker_push_thread():
                                 "mode": "CPA仓管" if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False) else ("Sub2Api" if getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False) else "常规量产")
                             }
 
-                            parsed_logs = []
-                            recent = list(log_history)[-50:]
-                            for raw in recent:
-                                m = re.match(r"^\[(.*?)\]\s*\[(.*?)\]\s+(.*)$", raw.strip())
-                                if m: parsed_logs.append({"parsed": True, "time": m.group(1), "level": m.group(2).upper(), "text": m.group(3), "raw": raw})
-                                else: parsed_logs.append({"parsed": False, "raw": raw})
+                            _, parsed_logs, changed = log_cache.refresh(log_history)
 
-                            await ws.send(json.dumps({"stats": stats_payload, "logs": parsed_logs}))
+                            if changed or is_running:
+                                await ws.send(json.dumps({"stats": stats_payload, "logs": parsed_logs}))
+                            else:
+                                await ws.send(json.dumps({"stats": stats_payload}))
 
                             resp_str = await ws.recv()
                             cmd = json.loads(resp_str).get("command", "none")
@@ -178,7 +178,7 @@ def _worker_push_thread():
                                         print(f"[{core_engine.ts()}] [ERROR] ❌ 账号上传总控失败: {e}")
                                 threading.Thread(target=_upload_task, daemon=True).start()
 
-                            await asyncio.sleep(0.5)
+                            await asyncio.sleep(push_interval if is_running else 3.0)
                 except Exception: pass
             await asyncio.sleep(3)
     asyncio.run(_ws_loop())

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -10,7 +10,6 @@ import warnings
 import subprocess
 import socket
 import socks
-import itertools
 warnings.filterwarnings("ignore", category=RuntimeWarning, module="trio")
 
 from fastapi import FastAPI
@@ -135,7 +134,7 @@ def _worker_push_thread():
                             }
 
                             parsed_logs = []
-                            recent = list(itertools.islice(log_history, max(0, len(log_history) - 50), len(log_history)))
+                            recent = list(log_history)[-50:]
                             for raw in recent:
                                 m = re.match(r"^\[(.*?)\]\s*\[(.*?)\]\s+(.*)$", raw.strip())
                                 if m: parsed_logs.append({"parsed": True, "time": m.group(1), "level": m.group(2).upper(), "text": m.group(3), "raw": raw})


### PR DESCRIPTION
## Summary

Fix multiple memory leak and memory pressure patterns that cause RSS to grow monotonically until the container OOMs.

Closes #50.

## Problem

Issue #50 reports that memory usage keeps climbing until the server runs out of memory and becomes completely unresponsive. After diagnosis, we identified four contributing factors:

1. `log_history` unbounded growth

`log_history` was a plain list that grew without limit. The trimming logic (`MAX_LOG_LINES`) existed in config but was either bypassed or never effective because multiple call sites appended directly to the list instead of going through the trim helper. Over a long-running session, this list could accumulate hundreds of thousands of entries and never shrink.

2. `curl_cffi` Session accumulation

In both the registration retry loop and the OAuth retry loop, a new `curl_cffi.requests.Session` was created to replace the previous one, but the old session was never explicitly closed before reassignment. `curl_cffi` wraps libcurl at the C layer; each session holds DNS cache, SSL session cache, and connection pool memory that Python's garbage collector cannot deterministically reclaim. Over thousands of retries these abandoned sessions pile up.

3. ThreadPoolExecutor lifecycle churn

The multi-threaded hot paths repeatedly create and tear down fresh `ThreadPoolExecutor` instances every batch iteration. This is not a classic unbounded leak, but under long-running high-concurrency workloads, the constant allocation and release of thread stacks, thread-local storage, task queues, and internal executor state creates significant allocator churn. Python's pymalloc arena allocator and the OS-level allocator do not reliably return this memory to the OS, so RSS trends upward and rarely falls back.

4. WebSocket high-frequency push churn

The WebSocket status push loop originally rebuilt `stats_payload`, re-parsed up to 50 log lines through regex, serialized a fresh JSON payload, and sent it every 0.5 seconds unconditionally. This produces a continuous stream of short-lived dict, list, and str objects. While individually reclaimable, Python's allocator tends to reuse memory pages rather than returning them to the OS, so RSS exhibits a "only goes up, rarely comes down" pattern. This acts as a memory pressure amplifier on top of the other leak sources.

## Changes

### For #1 - replace `log_history` with a bounded deque

- change `log_history` from `list` to `deque(maxlen=MAX_LOG_LINES)` so it auto-evicts oldest entries
- unify all append sites through `append_log()`, removing direct `log_history.append(...)` calls in `wfxl_openai_regst.py` and `routers/api_routes.py`
- document `max_log_lines` as a startup-only setting (runtime config reload no longer rebinds the deque, avoiding the import-by-value trap where consumers keep a reference to the old object)

### For #2 - eagerly close replaced `curl_cffi` sessions

- call `.close()` on the previous session before creating its replacement in both the registration retry loop and the OAuth retry loop
- call `gc.collect()` in the final cleanup block to help reclaim C-layer cyclic references

### For #3 - persistent `ThreadPoolExecutor` on `RegEngine`

- add a `_executor` field to `RegEngine`, created once at task start via `_ensure_executor()` and shut down on `stop()` via `_shutdown_executor()`
- add `_finalize_thread_run()` to consolidate cleanup in the finally block of the threaded runners, including normal mode, so the executor is also reclaimed when a task completes naturally (not only on explicit stop())
- all loop functions (`normal_main_loop`, `cpa_main_loop`, `sub2api_main_loop`, `manual_check_main_loop`, `perform_cpa_check`, `perform_sub2api_check`) accept an optional `executor` parameter; when provided, the hot-loop paths reuse the persistent pool instead of creating a fresh one per batch
- the standalone CLI entry point (`main()`) is unchanged and still creates ad-hoc executors

### For #4 - incremental log parsing and adaptive push interval

- add `RecentParsedLogCache` that tracks the last log window and only regex-parses newly appended entries, reusing previously parsed objects for the overlapping portion
- skip the log payload entirely when logs are unchanged and the engine is idle
- slow the push interval from 1 s to 3 s while the engine is not running
- switch the log snapshot from live `itertools.islice` to a safe `list(log_history)[-50:]` copy, preventing `RuntimeError('deque mutated during iteration')`

## Test

```bash
python -m pytest tests/test_log_stream_cache.py tests/test_reg_engine_executor_cleanup.py -q
python -m py_compile global_state.py wfxl_openai_regst.py utils/register.py routers/api_routes.py utils/core_engine.py tests/test_reg_engine_executor_cleanup.py
```
