### PR TITLE
新增邮箱域名运行时控制与冷却管理

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,12 @@ email_api_mode: "cloudflare_temp_email"
 # 你的域名 (支持逗号分隔多域名随机轮换) 如果只有一个域名就只填一个域名
 
 mail_domains: "domain1.com,domain2.xyz,domain3.net"
+disabled_mail_domains: []
+enable_mail_domain_runtime_control: false
+mail_domain_failure_types:
+  - discarded_email
+mail_domain_fail_threshold: 3
+mail_domain_fail_cooldown_sec: 600
 
 #二级域名开关
 enable_sub_domains: false

--- a/index.html
+++ b/index.html
@@ -227,6 +227,10 @@
                         <span class="text-slate-300 hidden sm:inline">•</span>
                         <span class="text-slate-500 font-bold whitespace-nowrap">失败 <span class="text-rose-500 font-black ml-0.5">{{stats.failed}}</span></span>
                         <span class="text-slate-300 hidden sm:inline">•</span>
+                        <span class="text-slate-500 font-bold whitespace-nowrap">可用域名 <span class="text-emerald-500 font-black ml-0.5">{{stats.available_count || 0}}</span></span>
+                        <span class="text-slate-300 hidden sm:inline">•</span>
+                        <span class="text-slate-500 font-bold whitespace-nowrap">冷却域名 <span class="text-amber-500 font-black ml-0.5">{{stats.cooldown_count || 0}}</span></span>
+                        <span class="text-slate-300 hidden sm:inline">•</span>
                         <span class="text-slate-500 font-bold whitespace-nowrap">风控拦截 <span class="text-amber-500 font-black ml-0.5">{{stats.retries}}</span></span>
                         <span class="text-slate-300 hidden sm:inline">•</span>
                         <span class="text-slate-500 font-bold whitespace-nowrap">密码受阻 <span class="text-orange-500 font-black ml-0.5">{{stats.pwd_blocked || 0}}</span></span>
@@ -839,6 +843,128 @@
                                         <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.542-7a9.97 9.97 0 012.67-3.835m2.89-2.89A9.97 9.97 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.05 10.05 0 01-1.875 3.175m-2.89 2.89l-1.414-1.414M12 15a3 3 0 100-6 3 3 0 000 6z"></path></svg>
                                     </button>
                                     </button>
+                                </div>
+
+                                <div class="mt-5 p-5 md:p-6 bg-gradient-to-br from-amber-50/80 to-white rounded-2xl border border-amber-100 shadow-sm flex flex-col gap-4">
+                                    <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
+                                        <div>
+                                            <h4 class="text-sm font-black text-amber-600 tracking-wide">黄金矿工模式</h4>
+                                            <p class="text-xs text-slate-500 mt-1 font-medium">开启后按主域统计异常，并在超限后自动冷却。</p>
+                                            <p class="text-[11px] text-slate-400 mt-1">超限域名会暂时停用；关闭后恢复随机使用，不计数、不冷却。</p>
+                                            <p v-if="!['cloudflare_temp_email', 'freemail', 'cloudmail', 'openai_cpa'].includes(config.email_api_mode)" class="text-[11px] font-bold text-rose-600 mt-3 bg-rose-50 px-3 py-2 rounded-lg inline-block border border-rose-100 shadow-sm flex items-center gap-1.5">
+                                                <span><svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg></span> 当前模式不支持此功能！仅限 cloudflare_temp_email, freemail, cloudmail, openai_cpa。
+                                            </p>
+                                        </div>
+                                        <label class="relative inline-flex items-center shrink-0 mt-3 sm:mt-0" :class="['cloudflare_temp_email', 'freemail', 'cloudmail', 'openai_cpa'].includes(config.email_api_mode) ? 'cursor-pointer' : 'cursor-not-allowed opacity-50 grayscale'">
+                                            <input type="checkbox" v-model="config.enable_mail_domain_runtime_control" :disabled="!['cloudflare_temp_email', 'freemail', 'cloudmail', 'openai_cpa'].includes(config.email_api_mode)" class="sr-only peer">
+                                            <div class="relative w-11 h-6 bg-slate-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-amber-500 shadow-inner transition-colors duration-300"></div>
+                                        </label>
+                                    </div>
+
+                                    <div v-if="config.enable_mail_domain_runtime_control" class="border-t border-amber-100/60 pt-5 mt-2 space-y-5">
+                                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                            <div>
+                                                <label class="block text-slate-700 text-xs font-black mb-2 uppercase tracking-wider">冷却阈值</label>
+                                                <input type="number" min="0" v-model.number="config.mail_domain_fail_threshold"
+                                                       class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
+                                                       placeholder="例如 3">
+                                                <p class="text-[11px] text-slate-400 mt-2 font-medium">同一主域异常达到该次数后暂停使用，0 表示关闭。</p>
+                                            </div>
+                                            <div>
+                                                <label class="block text-slate-700 text-xs font-black mb-2 uppercase tracking-wider">冷却秒数</label>
+                                                <input type="number" min="0" v-model.number="config.mail_domain_fail_cooldown_sec"
+                                                       class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
+                                                       placeholder="例如 600">
+                                                <p class="text-[11px] text-slate-400 mt-2 font-medium">触发阈值后，该主域暂停使用的时长。</p>
+                                            </div>
+                                        </div>
+
+                                        <div>
+                                            <label class="block text-slate-700 text-xs font-black mb-3 uppercase tracking-wider">异常判断逻辑</label>
+                                            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+                                                <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                                    <input type="checkbox" value="discarded_email" v-model="config.mail_domain_failure_types" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                                    <div>
+                                                        <div class="text-sm font-black text-slate-700">邮件丢弃异常</div>
+                                                        <div class="text-[11px] text-slate-400 mt-1">统计验证码重试耗尽后的丢弃异常。</div>
+                                                    </div>
+                                                </label>
+                                                <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                                    <input type="checkbox" value="cloudflare_temp_email_network" v-model="config.mail_domain_failure_types" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                                    <div>
+                                                        <div class="text-sm font-black text-slate-700">网络异常</div>
+                                                        <div class="text-[11px] text-slate-400 mt-1">统计申请邮箱时的网络异常。</div>
+                                                    </div>
+                                                </label>
+                                                <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                                    <input type="checkbox" value="capacity_exceeded" v-model="config.mail_domain_failure_types" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                                    <div>
+                                                        <div class="text-sm font-black text-slate-700">容量超限异常</div>
+                                                        <div class="text-[11px] text-slate-400 mt-1">统计返回的限额或容量超限。</div>
+                                                    </div>
+                                                </label>
+                                            </div>
+                                            <p class="text-[11px] text-slate-400 mt-2 font-medium">仅勾选的异常类型会累计到当前域名的异常计数并参与冷却判断。</p>
+                                        </div>
+
+                                        <div class="p-4 bg-slate-50 border border-slate-200 rounded-xl">
+                                            <div class="flex items-center justify-between gap-3 mb-3">
+                                                <div>
+                                                    <h4 class="text-sm font-black text-slate-700">域名列表</h4>
+                                                    <p class="text-[11px] text-slate-400 mt-1 font-medium">仅展示当前进程内的主域名计数与冷却状态，重启后会重新统计。</p>
+                                                    <p class="text-[11px] text-slate-400 mt-1 font-medium">可用 {{ availableMailDomainCount }} / 冷却 {{ cooldownMailDomainCount }}</p>
+                                                </div>
+                                                <div class="flex items-center gap-2 flex-wrap justify-end">
+                                                    <button @click="toggleMailDomainRuntimePanel" type="button" :title="mailDomainRuntimePanelCollapsed ? '展开状态' : '隐藏状态'" :aria-label="mailDomainRuntimePanelCollapsed ? '展开状态' : '隐藏状态'" class="text-lg text-slate-400 hover:text-indigo-600 focus:outline-none transition-transform hover:scale-110">
+                                                        <svg v-if="!mailDomainRuntimePanelCollapsed" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path></svg>
+                                                        <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.542-7a9.97 9.97 0 012.67-3.835m2.89-2.89A9.97 9.97 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.05 10.05 0 01-1.875 3.175m-2.89 2.89l-1.414-1.414M12 15a3 3 0 100-6 3 3 0 000 6z"></path></svg>
+                                                    </button>
+                                                    <button @click="clearMailDomainRuntimeCooldowns" type="button" class="px-3 py-2 text-xs font-black rounded-lg border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors shadow-sm">清除冷却</button>
+                                                </div>
+                                            </div>
+                                            <div v-show="!mailDomainRuntimePanelCollapsed">
+                                                <div v-if="mailDomainRuntimeStatsError" class="text-xs text-rose-500 font-medium bg-rose-50 border border-rose-200 rounded-xl px-4 py-4 mb-3">
+                                                    {{ mailDomainRuntimeStatsError }}
+                                                </div>
+                                                <div v-if="mailDomainRuntimeStats.length > 0" class="space-y-3">
+                                                    <div v-for="item in mailDomainRuntimeStats" :key="item.domain" class="bg-white border border-slate-200 rounded-xl p-4 shadow-sm">
+                                                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
+                                                            <div>
+                                                                <div class="text-sm font-black text-slate-800 break-all">{{ item.domain }}</div>
+                                                                <div class="text-[11px] text-slate-400 mt-1">
+                                                                    最近使用: {{ item.last_used_at ? new Date(item.last_used_at * 1000).toLocaleString('zh-CN', { hour12: false }) : '未使用' }}
+                                                                </div>
+                                                                <div v-if="isMailDomainRuntimePristine(item)" class="text-[11px] text-sky-500 mt-1 font-medium">
+                                                                    尚未参与运行，等待首次分配。
+                                                                </div>
+                                                            </div>
+                                                            <div class="flex items-center gap-2 flex-wrap justify-end">
+                                                                <button @click="toggleMailDomainDisabled(item.domain)" type="button" :class="item.is_disabled ? 'border-emerald-200 text-emerald-700 hover:bg-emerald-50' : 'border-rose-200 text-rose-600 hover:bg-rose-50'" class="px-3 py-1.5 text-[11px] font-black rounded-lg border bg-white transition-colors shadow-sm">
+                                                                    {{ item.is_disabled ? '启用' : '禁用' }}
+                                                                </button>
+                                                                <button @click="clearMailDomainRuntimeRowCounters(item.domain)" type="button" class="px-3 py-1.5 text-[11px] font-black rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors shadow-sm">清空计数</button>
+                                                                <button @click="clearMailDomainRuntimeRowCooldown(item.domain)" type="button" class="px-3 py-1.5 text-[11px] font-black rounded-lg border border-amber-200 bg-white text-amber-700 hover:bg-amber-50 transition-colors shadow-sm">清除冷却</button>
+                                                                <span :class="item.is_disabled ? 'bg-slate-200 text-slate-700 border-slate-300' : 'bg-emerald-100 text-emerald-700 border-emerald-200'" class="inline-flex items-center px-3 py-1 rounded-full text-[11px] font-black border w-max">
+                                                                    {{ item.is_disabled ? '停用' : '启用' }}
+                                                                </span>
+                                                                <span :class="item.is_available ? 'bg-emerald-100 text-emerald-700 border-emerald-200' : 'bg-amber-100 text-amber-700 border-amber-200'" class="inline-flex items-center px-3 py-1 rounded-full text-[11px] font-black border w-max">
+                                                                    {{ item.is_available ? '可用' : '冷却中' }}
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                        <div class="grid grid-cols-2 lg:grid-cols-3 gap-3 text-xs font-bold text-slate-600">
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">异常: <span class="text-slate-800">{{ item.fail_count }}</span></div>
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">成功: <span class="text-slate-800">{{ item.success_count }}</span></div>
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">时间: <span class="text-slate-800">{{ formatDuration(item.cooldown_remaining_sec || 0) }}</span></div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div v-else class="text-xs text-slate-400 font-medium bg-white border border-dashed border-slate-200 rounded-xl px-4 py-4">
+                                                    当前还没有域名运行时统计数据，开始注册后这里会显示各主域名的成功/异常计数与冷却状态。
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
 
                                 <div class="mt-8 p-5 md:p-6 bg-slate-50/80 rounded-2xl border border-slate-200 shadow-sm">

--- a/routers/system_routes.py
+++ b/routers/system_routes.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from global_state import VALID_TOKENS, CLUSTER_NODES, NODE_COMMANDS, cluster_lock, log_history, engine, verify_token, worker_status, append_log
 from utils import core_engine, db_manager
+from utils.email_providers import mail_service
 from utils.config import reload_all_configs
 from utils.integrations.tg_notifier import send_tg_msg_async
 import utils.config as cfg
@@ -27,6 +28,7 @@ class DummyArgs:
         self.once = once
 
 class LoginData(BaseModel): password: str
+class DomainRuntimeActionReq(BaseModel): domain: str
 class ClusterUploadAccountsReq(BaseModel): node_name: str; secret: str; accounts: list
 class ClusterReportReq(BaseModel): node_name: str; secret: str; stats: dict; logs: list
 class ClusterControlReq(BaseModel): node_name: str; action: str
@@ -121,6 +123,7 @@ async def start_task(token: str = Depends(verify_token)):
     default_proxy = getattr(core_engine.cfg, 'DEFAULT_PROXY', None)
     args = DummyArgs(proxy=default_proxy if default_proxy else None)
     core_engine.run_stats.update({"success": 0, "failed": 0, "retries": 0, "pwd_blocked": 0, "phone_verify": 0, "start_time": time.time(),"target": 0})
+    mail_service.start_mail_domain_runtime_tracking()
     if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False):
         engine.start_cpa(args)
         return {"status": "success", "message": "启动成功：已自动识别并开启 [CPA 智能仓管模式]"}
@@ -155,6 +158,7 @@ async def stop_task(token: str = Depends(verify_token)):
 
     asyncio.create_task(send_tg_msg_async(msg))
     engine.stop()
+    mail_service.stop_mail_domain_runtime_tracking()
     return {"status": "success", "message": "已发送停止指令，正在安全退出..."}
 
 
@@ -190,12 +194,16 @@ async def get_stats(token: str = Depends(verify_token)):
         current_mode = "CPA 仓管" if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False) else (
             "Sub2Api 仓管" if getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False) else "常规量产")
 
+    domain_summary = mail_service.get_mail_domain_runtime_summary()
+
     return {
         "success": stats["success"], "failed": stats["failed"], "retries": stats["retries"],
         "pwd_blocked": stats.get("pwd_blocked", 0), "phone_verify": stats.get("phone_verify", 0),
         "total": total_attempts, "target": stats["target"] if stats["target"] > 0 else "∞",
         "success_rate": f"{success_rate}%", "elapsed": f"{elapsed}s", "avg_time": f"{avg_time}s",
-        "progress_pct": f"{progress_pct}%", "is_running": is_running, "mode": current_mode
+        "progress_pct": f"{progress_pct}%", "is_running": is_running, "mode": current_mode,
+        "available_count": domain_summary.get("available_count", 0),
+        "cooldown_count": domain_summary.get("cooldown_count", 0),
     }
 
 
@@ -241,13 +249,50 @@ async def get_config(token: str = Depends(verify_token)):
     return config_data
 
 
+@router.get("/api/config/mail_domain_runtime_stats")
+async def get_mail_domain_runtime_stats(token: str = Depends(verify_token)):
+    return {"status": "success", "items": mail_service.get_mail_domain_runtime_stats()}
+
+
+@router.post("/api/config/mail_domain_runtime_stats/clear")
+async def clear_mail_domain_runtime_stats(token: str = Depends(verify_token)):
+    cleared_count = mail_service.clear_all_mail_domain_runtime_cooldowns()
+    return {"status": "success", "message": f"已清除 {cleared_count} 个域名冷却"}
+
+
+@router.post("/api/config/mail_domain_runtime_stats/clear_counters")
+async def clear_mail_domain_runtime_domain_counters(req: DomainRuntimeActionReq, token: str = Depends(verify_token)):
+    item = mail_service.clear_mail_domain_runtime_domain_counters(req.domain)
+    if not item:
+        return {"status": "error", "message": "未找到指定域名的运行时计数"}
+    return {"status": "success", "message": f"已清空 {item['domain']} 的计数", "item": item}
+
+
+@router.post("/api/config/mail_domain_runtime_stats/clear_cooldown")
+async def clear_mail_domain_runtime_domain_cooldown(req: DomainRuntimeActionReq, token: str = Depends(verify_token)):
+    item = mail_service.clear_mail_domain_runtime_domain_cooldown(req.domain)
+    if not item:
+        return {"status": "error", "message": "未找到指定域名的冷却状态"}
+    return {"status": "success", "message": f"已清除 {item['domain']} 的冷却", "item": item}
+
+
 @router.post("/api/config")
 async def save_config(new_config: dict, token: str = Depends(verify_token)):
     try:
         if isinstance(new_config.get("sub2api_mode"), dict):
             new_config["sub2api_mode"].pop("min_remaining_weekly_percent", None)
         new_config["local_microsoft"] = _sanitize_local_microsoft_config(new_config.get("local_microsoft"))
+        if not isinstance(new_config.get("disabled_mail_domains"), list):
+            new_config["disabled_mail_domains"] = []
+        if not isinstance(new_config.get("mail_domain_failure_types"), list):
+            new_config["mail_domain_failure_types"] = ["discarded_email"]
+        new_config["mail_domain_failure_types"] = list(dict.fromkeys(
+            str(item or "").strip().lower()
+            for item in new_config.get("mail_domain_failure_types", [])
+            if str(item or "").strip()
+        )) or ["discarded_email"]
         reload_all_configs(new_config_dict=new_config)
+        mail_service.sync_mail_domain_runtime_state_with_config()
 
         return {"status": "success", "message": "✅ 配置已成功保存并同步至云端！"}
     except Exception as e:
@@ -552,12 +597,14 @@ def ext_reset_stats(token: str = Depends(verify_token)):
         "target": getattr(core_engine.cfg, 'NORMAL_TARGET_COUNT', 0),
         "ext_is_running": True
     })
+    mail_service.start_mail_domain_runtime_tracking()
     return {"status": "success"}
 
 @router.post("/api/ext/stop")
 def ext_stop(token: str = Depends(verify_token)):
     from utils import core_engine
     core_engine.run_stats["ext_is_running"] = False
+    mail_service.stop_mail_domain_runtime_tracking()
     return {"status": "success"}
 
 @router.get("/api/system/version")

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -74,6 +74,10 @@ createApp({
             logBuffer: [],
             logFlushTimer: null,
             config: null,
+            mailDomainRuntimeStats: [],
+            mailDomainRuntimeStatsError: '',
+            mailDomainRuntimePanelCollapsed: normalizeBooleanLike(localStorage.getItem('mail_domain_runtime_panel_collapsed'), false),
+            mailDomainRuntimeLastFetchAt: 0,
             blacklistStr: "",
             warpListStr: "",
             rawProxyListStr: "",
@@ -231,6 +235,15 @@ createApp({
         searchMailboxes() {
             this.mailboxPage = 1;
             this.fetchMailboxes();
+        },
+        'config.email_api_mode'(nextMode) {
+            const supportedModes = ['cloudflare_temp_email', 'freemail', 'cloudmail', 'openai_cpa'];
+            if (!supportedModes.includes(String(nextMode || '').trim())) {
+                this.config.enable_mail_domain_runtime_control = false;
+                this.mailDomainRuntimeStats = [];
+                this.mailDomainRuntimeStatsError = '';
+                this.mailDomainRuntimeLastFetchAt = 0;
+            }
         }
     },
     mounted() {
@@ -285,6 +298,12 @@ createApp({
         },
         mailboxTotalPages() {
             return Math.ceil(this.totalMailboxes / this.mailboxPageSize) || 1;
+        },
+        availableMailDomainCount() {
+            return this.mailDomainRuntimeStats.filter(item => item && item.is_available).length;
+        },
+        cooldownMailDomainCount() {
+            return this.mailDomainRuntimeStats.filter(item => item && !item.is_available).length;
         }
     },
     methods: {
@@ -363,6 +382,13 @@ createApp({
         },
         async initApp() {
             await this.fetchConfig();
+            if (this.config?.enable_mail_domain_runtime_control) {
+                await this.fetchMailDomainRuntimeStats();
+            } else {
+                this.mailDomainRuntimeStats = [];
+                this.mailDomainRuntimeStatsError = '';
+                this.mailDomainRuntimeLastFetchAt = 0;
+            }
             this.initSSE();
             this.fetchAccounts();
             this.fetchCloudAccounts();
@@ -404,9 +430,19 @@ createApp({
                             this.dispatchExtensionTask();
                         }
                     }
-                this.stats = data;
+                    this.stats = data;
                 } else {
                     this.isRunning = data.is_running;
+                }
+
+                if (
+                    this.currentTab === 'email' &&
+                    this.isRunning &&
+                    this.config?.enable_mail_domain_runtime_control &&
+                    !this.mailDomainRuntimePanelCollapsed &&
+                    Date.now() - this.mailDomainRuntimeLastFetchAt >= 1000
+                ) {
+                    this.fetchMailDomainRuntimeStats({ silent: true });
                 }
 
                 if (this.currentTab === 'cluster') {
@@ -595,7 +631,131 @@ createApp({
                 if (this.config.cluster_node_name === undefined) this.config.cluster_node_name = '';
                 if (this.config.cluster_master_url === undefined) this.config.cluster_master_url = '';
                 if (this.config.cluster_secret === undefined) this.config.cluster_secret = 'wenfxl666';
+                if (!Array.isArray(this.config.disabled_mail_domains)) this.config.disabled_mail_domains = [];
+                this.config.disabled_mail_domains = [...new Set(
+                    this.config.disabled_mail_domains
+                        .map(item => String(item || '').trim().toLowerCase().replace(/^\.+|\.+$/g, ''))
+                        .filter(Boolean)
+                )];
+                if (this.config.enable_mail_domain_runtime_control === undefined) this.config.enable_mail_domain_runtime_control = false;
+                this.config.enable_mail_domain_runtime_control = normalizeBooleanLike(this.config.enable_mail_domain_runtime_control, false);
+                if (!Array.isArray(this.config.mail_domain_failure_types)) this.config.mail_domain_failure_types = ['discarded_email'];
+                this.config.mail_domain_failure_types = [...new Set(
+                    this.config.mail_domain_failure_types
+                        .map(item => String(item || '').trim().toLowerCase())
+                        .filter(Boolean)
+                )];
+                if (this.config.mail_domain_failure_types.length === 0) this.config.mail_domain_failure_types = ['discarded_email'];
+                if (this.config.mail_domain_fail_threshold === undefined) this.config.mail_domain_fail_threshold = 3;
+                if (this.config.mail_domain_fail_cooldown_sec === undefined) this.config.mail_domain_fail_cooldown_sec = 600;
             } catch (e) {}
+        },
+        async fetchMailDomainRuntimeStats(options = {}) {
+            const { silent = false } = options;
+            if (!this.config?.enable_mail_domain_runtime_control) {
+                this.mailDomainRuntimeStats = [];
+                this.mailDomainRuntimeStatsError = '';
+                this.mailDomainRuntimeLastFetchAt = 0;
+                return;
+            }
+            try {
+                const res = await this.authFetch('/api/config/mail_domain_runtime_stats');
+                const data = await res.json();
+                if (data.status === 'success' && Array.isArray(data.items)) {
+                    this.mailDomainRuntimeStats = data.items;
+                    this.mailDomainRuntimeStatsError = '';
+                    this.mailDomainRuntimeLastFetchAt = Date.now();
+                } else {
+                    this.mailDomainRuntimeStatsError = data.message || '域名运行时状态获取失败';
+                    if (!silent) {
+                        this.showToast(this.mailDomainRuntimeStatsError, 'error');
+                    }
+                }
+            } catch (e) {
+                this.mailDomainRuntimeStatsError = '域名运行时状态获取失败，请检查后端接口或网络连接';
+                if (!silent) {
+                    this.showToast(this.mailDomainRuntimeStatsError, 'error');
+                }
+            }
+        },
+        toggleMailDomainRuntimePanel() {
+            this.mailDomainRuntimePanelCollapsed = !this.mailDomainRuntimePanelCollapsed;
+            localStorage.setItem('mail_domain_runtime_panel_collapsed', this.mailDomainRuntimePanelCollapsed ? 'true' : 'false');
+        },
+        isMailDomainRuntimePristine(item) {
+            if (!item || typeof item !== 'object') return false;
+            return !item.last_used_at && !item.success_count && !item.fail_count && !(item.cooldown_remaining_sec > 0);
+        },
+        toggleMailDomainDisabled(domain) {
+            const normalized = String(domain || '').trim().toLowerCase().replace(/^\.+|\.+$/g, '');
+            if (!normalized) return;
+            if (!Array.isArray(this.config.disabled_mail_domains)) {
+                this.config.disabled_mail_domains = [];
+            }
+            const next = new Set(
+                this.config.disabled_mail_domains
+                    .map(item => String(item || '').trim().toLowerCase().replace(/^\.+|\.+$/g, ''))
+                    .filter(Boolean)
+            );
+            if (next.has(normalized)) {
+                next.delete(normalized);
+            } else {
+                next.add(normalized);
+            }
+            this.config.disabled_mail_domains = Array.from(next);
+            this.saveConfig();
+        },
+        async clearMailDomainRuntimeCooldowns() {
+            try {
+                const res = await this.authFetch('/api/config/mail_domain_runtime_stats/clear', { method: 'POST' });
+                const data = await res.json();
+                if (data.status === 'success') {
+                    this.mailDomainRuntimeStatsError = '';
+                    this.showToast(data.message || '已清除全部域名冷却', 'success');
+                    await this.fetchMailDomainRuntimeStats({ silent: true });
+                    this.pollStats();
+                } else {
+                    this.showToast(data.message || '清除全部域名冷却失败', 'error');
+                }
+            } catch (e) {
+                this.showToast('清除全部域名冷却失败，请检查网络连接', 'error');
+            }
+        },
+        async clearMailDomainRuntimeRowCounters(domain) {
+            try {
+                const res = await this.authFetch('/api/config/mail_domain_runtime_stats/clear_counters', {
+                    method: 'POST',
+                    body: JSON.stringify({ domain })
+                });
+                const data = await res.json();
+                if (data.status === 'success') {
+                    this.showToast(data.message || '已清空域名计数', 'success');
+                    await this.fetchMailDomainRuntimeStats({ silent: true });
+                    this.pollStats();
+                } else {
+                    this.showToast(data.message || '清空域名计数失败', 'error');
+                }
+            } catch (e) {
+                this.showToast('清空域名计数失败，请检查网络连接', 'error');
+            }
+        },
+        async clearMailDomainRuntimeRowCooldown(domain) {
+            try {
+                const res = await this.authFetch('/api/config/mail_domain_runtime_stats/clear_cooldown', {
+                    method: 'POST',
+                    body: JSON.stringify({ domain })
+                });
+                const data = await res.json();
+                if (data.status === 'success') {
+                    this.showToast(data.message || '已清除域名冷却', 'success');
+                    await this.fetchMailDomainRuntimeStats({ silent: true });
+                    this.pollStats();
+                } else {
+                    this.showToast(data.message || '清除域名冷却失败', 'error');
+                }
+            } catch (e) {
+                this.showToast('清除域名冷却失败，请检查网络连接', 'error');
+            }
         },
         async saveConfig() {
             try {
@@ -625,6 +785,33 @@ createApp({
                     this.config.local_microsoft.suffix_len_min = minLen;
                     this.config.local_microsoft.suffix_len_max = maxLen;
                 }
+                this.config.enable_mail_domain_runtime_control = normalizeBooleanLike(this.config.enable_mail_domain_runtime_control, false);
+                if (!Array.isArray(this.config.mail_domain_failure_types)) {
+                    this.config.mail_domain_failure_types = ['discarded_email'];
+                }
+                this.config.mail_domain_failure_types = [...new Set(
+                    this.config.mail_domain_failure_types
+                        .map(item => String(item || '').trim().toLowerCase())
+                        .filter(Boolean)
+                )];
+                if (this.config.mail_domain_failure_types.length === 0) {
+                    this.config.mail_domain_failure_types = ['discarded_email'];
+                }
+                if (!this.config.enable_mail_domain_runtime_control) {
+                    this.mailDomainRuntimeStats = [];
+                    this.mailDomainRuntimeStatsError = '';
+                    this.mailDomainRuntimeLastFetchAt = 0;
+                }
+                if (!Array.isArray(this.config.disabled_mail_domains)) {
+                    this.config.disabled_mail_domains = [];
+                }
+                this.config.disabled_mail_domains = [...new Set(
+                    this.config.disabled_mail_domains
+                        .map(item => String(item || '').trim().toLowerCase().replace(/^\.+|\.+$/g, ''))
+                        .filter(Boolean)
+                )];
+                this.config.mail_domain_fail_threshold = Math.max(0, parseInt(this.config.mail_domain_fail_threshold, 10) || 0);
+                this.config.mail_domain_fail_cooldown_sec = Math.max(0, parseInt(this.config.mail_domain_fail_cooldown_sec, 10) || 0);
                 this.config.warp_proxy_list = this.warpListStr.split('\n').map(s => s.trim()).filter(s => s);
                 if (!this.config.raw_proxy_pool || typeof this.config.raw_proxy_pool !== 'object' || Array.isArray(this.config.raw_proxy_pool)) {
                     this.config.raw_proxy_pool = { enable: false, proxy_list: [] };
@@ -637,6 +824,8 @@ createApp({
                 const data = await res.json();
                 if(data.status === 'success') {
                     this.showToast(data.message, "success");
+                    await this.fetchConfig();
+                    await this.fetchMailDomainRuntimeStats();
                     this.pollStats();
                 } else { this.showToast("保存失败：" + data.message, "error"); }
             } catch (e) { this.showToast("保存失败网络异常", "error"); }
@@ -716,6 +905,7 @@ createApp({
             }
 			if (tabId === 'email') {
 				this.fetchConfig();
+                    this.fetchMailDomainRuntimeStats();
 			}
 			if (tabId === 'cloud') {
 			    this.fetchCloudAccounts();
@@ -956,6 +1146,7 @@ createApp({
                     this.isRunning = true;
                     this.currentTab = 'console';
                     this.pollStats();
+                    await this.fetchMailDomainRuntimeStats();
                     this.showToast(`启动成功`, "success");
                 } else { this.showToast(data.message, "error"); }
             } catch (e) { this.showToast("启动请求发送失败", "error"); }
@@ -966,6 +1157,7 @@ createApp({
                 const data = await res.json();
                 this.showToast("任务已停止", "info");
                 this.isRunning = false;
+                await this.fetchMailDomainRuntimeStats();
                 const now = new Date();
                 const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false }); // 获取如 14:30:05 格式
                 this.logs.push({

--- a/utils/auth_pipeline/register.py
+++ b/utils/auth_pipeline/register.py
@@ -226,6 +226,9 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
                         if not login_code and (code_resp is None or code_resp.status_code != 200):
                             print(
                                 f"[{cfg.ts()}] [ERROR] 无密码通道验证码重试达上限 ({cfg.MAX_OTP_RETRIES} 次)，丢弃当前 {mask_email(email)} 邮箱。")
+                            if run_ctx is not None:
+                                run_ctx['discarded_email_failure'] = True
+                                run_ctx['mail_domain_failure_reason'] = 'discarded_email'
                             return None, None
 
                         code_url = str(code_resp.json().get("continue_url") or "").strip()
@@ -352,6 +355,9 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
 
                         if not code:
                             print(f"[{cfg.ts()}] [ERROR] 重试次数上限，丢弃当前 {mask_email(email)} 邮箱。")
+                            if run_ctx is not None:
+                                run_ctx['discarded_email_failure'] = True
+                                run_ctx['mail_domain_failure_reason'] = 'discarded_email'
                             return None, None
 
                         sentinel_otp = generate_payload(did=did, flow="authorize_continue", proxy=proxy, user_agent=current_ua,
@@ -728,6 +734,9 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
                         if not login_code_oauth and (login_code_resp is None or login_code_resp.status_code != 200):
                             print(
                                 f"[{cfg.ts()}] [ERROR] 无密码通道重试次数达上限 ({cfg.MAX_OTP_RETRIES} 次)，丢弃当前 {mask_email(email)} 邮箱，放弃接管。")
+                            if run_ctx is not None:
+                                run_ctx['discarded_email_failure'] = True
+                                run_ctx['mail_domain_failure_reason'] = 'discarded_email'
                             return None, None
 
                         login_code_url = str(login_code_resp.json().get("continue_url") or "").strip()

--- a/utils/config.py
+++ b/utils/config.py
@@ -186,6 +186,11 @@ ENABLE_SUB_DOMAINS: bool = False
 SUB_DOMAIN_COUNT: int = 10
 EMAIL_API_MODE: str = ""
 MAIL_DOMAINS: str = ""
+DISABLED_MAIL_DOMAINS: list[str] = []
+ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL: bool = False
+MAIL_DOMAIN_FAILURE_TYPES: list[str] = ["discarded_email"]
+MAIL_DOMAIN_FAIL_THRESHOLD: int = 3
+MAIL_DOMAIN_FAIL_COOLDOWN_SEC: int = 600
 GPTMAIL_BASE: str = ""
 ADMIN_AUTH: str = ""
 IMAP_SERVER: str = ""
@@ -395,6 +400,9 @@ def reload_all_configs(new_config_dict=None):
     global _c
     global WEB_PASSWORD
     global EMAIL_API_MODE, MAIL_DOMAINS, GPTMAIL_BASE, ADMIN_AUTH
+    global DISABLED_MAIL_DOMAINS
+    global ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL
+    global MAIL_DOMAIN_FAILURE_TYPES, MAIL_DOMAIN_FAIL_THRESHOLD, MAIL_DOMAIN_FAIL_COOLDOWN_SEC
     global ENABLE_SUB_DOMAINS, SUB_DOMAIN_COUNT
     global IMAP_SERVER, IMAP_PORT, IMAP_USER, IMAP_PASS
     global FREEMAIL_API_URL, FREEMAIL_API_TOKEN, FREEMAIL_LOCAL_WEBHOOK, FREEMAIL_WEBHOOK_SECRET
@@ -526,6 +534,17 @@ def reload_all_configs(new_config_dict=None):
             return max(minimum, parsed)
         return parsed
 
+    def normalize_domain_list(value):
+        items = value if isinstance(value, list) else []
+        seen = set()
+        domains = []
+        for item in items:
+            text = str(item or "").strip().lower().strip(".")
+            if text and text not in seen:
+                seen.add(text)
+                domains.append(text)
+        return domains
+
     def safe_bool(value, default=False):
         if isinstance(value, bool):
             return value
@@ -556,6 +575,16 @@ def reload_all_configs(new_config_dict=None):
 
     EMAIL_API_MODE = _c.get("email_api_mode", "cloudflare_temp_email")
     MAIL_DOMAINS = _c.get("mail_domains", "")
+    DISABLED_MAIL_DOMAINS = normalize_domain_list(_c.get("disabled_mail_domains", []))
+    ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL = safe_bool(_c.get("enable_mail_domain_runtime_control", False), default=False)
+    MAIL_DOMAIN_FAILURE_TYPES = [
+        str(item or "").strip().lower()
+        for item in (_c.get("mail_domain_failure_types", ["discarded_email"]) or ["discarded_email"])
+        if str(item or "").strip()
+    ]
+    MAIL_DOMAIN_FAILURE_TYPES = list(dict.fromkeys(MAIL_DOMAIN_FAILURE_TYPES)) or ["discarded_email"]
+    MAIL_DOMAIN_FAIL_THRESHOLD = safe_int(_c.get("mail_domain_fail_threshold", 3), default=3, minimum=0)
+    MAIL_DOMAIN_FAIL_COOLDOWN_SEC = safe_int(_c.get("mail_domain_fail_cooldown_sec", 600), default=600, minimum=0)
     GPTMAIL_BASE = str(_c.get("gptmail_base", "")).strip().rstrip("/")
     ADMIN_AUTH = _c.get("admin_auth", "")
 

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -574,6 +574,14 @@ def _handle_dead_account(name: str, is_disabled: bool) -> None:
         print(f"[{ts()}] [WARNING] 凭证 {mask_email(name)} 已死亡，当前已是禁用状态，根据配置保留不删除。")
 
 def handle_registration_result(result: Any, cpa_upload: bool = False, run_ctx: dict = None) -> str:
+    def _format_cooldown_time(cooldown_until: float) -> str:
+        if not cooldown_until:
+            return ""
+        try:
+            return datetime.fromtimestamp(float(cooldown_until)).strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return ""
+
     if getattr(cfg, 'GLOBAL_STOP', False):
         return "stopped"
     global run_stats
@@ -614,7 +622,10 @@ def handle_registration_result(result: Any, cpa_upload: bool = False, run_ctx: d
         token_json_str, password = result
         
     ret_status = "success"
-     
+    discarded_email_failure = run_ctx.get('discarded_email_failure', False) if run_ctx else False
+    domain_failure_reason = str(run_ctx.get('mail_domain_failure_reason', '') or '').strip().lower() if run_ctx else ''
+    domain_failure_event = mail_service.pop_last_domain_failure_event()
+
     if not token_json_str or token_json_str == "retry_403":
         if token_json_str == "retry_403":
             with _stats_lock: run_stats["retries"] += 1
@@ -622,15 +633,33 @@ def handle_registration_result(result: Any, cpa_upload: bool = False, run_ctx: d
             ret_status = "retry_403"
         else:
             with _stats_lock: run_stats["failed"] += 1
+            failure_domain = cur_dom
+            failure_reason = domain_failure_reason
+            if not failure_reason and discarded_email_failure:
+                failure_reason = 'discarded_email'
+            if not failure_reason and domain_failure_event:
+                failure_reason = str(domain_failure_event.get('reason') or '').strip().lower()
+                failure_domain = domain_failure_event.get('domain') or failure_domain
+            if failure_reason:
+                domain_result = mail_service.record_domain_failure(failure_domain, failure_reason)
+                if domain_result:
+                    cooldown_text = _format_cooldown_time(domain_result.get("cooldown_until", 0.0))
+                    extra_text = f"，冷却结束时间: {cooldown_text}" if cooldown_text else ""
+                    print(f"[{ts()}] [INFO] 失败域名 {mask_email(domain_result.get('domain', failure_domain or ''))} -> 异常 {domain_result.get('fail_count', 0)} / 成功 {domain_result.get('success_count', 0)} / 原因 {failure_reason}{extra_text}")
             ret_status = "failed"
         if cfg.ENABLE_SUB_DOMAINS:
-            mail_service.clear_sticky_domain() 
+            mail_service.clear_sticky_domain()
             print(f"[{ts()}] [系统] 域名 {mask_email(cur_dom or '')} 注册失败，下一轮重新生成。")
-            
+
     else:
         with _stats_lock: run_stats["success"] += 1
         token_data    = json.loads(token_json_str)
         account_email = token_data.get("email", "unknown")
+        domain_result = mail_service.record_domain_success(account_email if account_email and "@" in account_email else cur_dom)
+        if domain_result:
+            cooldown_text = _format_cooldown_time(domain_result.get("cooldown_until", 0.0))
+            extra_text = f"，冷却结束时间: {cooldown_text}" if cooldown_text else ""
+            print(f"[{ts()}] [INFO] 成功域名 {mask_email(domain_result.get('domain', cur_dom or ''))} -> 失败 {domain_result.get('fail_count', 0)} / 成功 {domain_result.get('success_count', 0)}{extra_text}")
 
         # 存入本地数据库
         if cpa_upload:

--- a/utils/email_providers/mail_service.py
+++ b/utils/email_providers/mail_service.py
@@ -49,6 +49,14 @@ luckmail_lock = threading.Lock()
 empty_retry_count = 0
 empty_lock = threading.Lock()
 _CM_TOKEN_CACHE: Optional[str] = None
+_DOMAIN_RUNTIME_LOCK = threading.Lock()
+_DOMAIN_RUNTIME_STATE = {}
+_MAIL_DOMAIN_FAILURE_TYPES = {"discarded_email", "cloudflare_temp_email_network", "capacity_exceeded"}
+_DOMAIN_RUNTIME_SESSION = {
+    "counting_enabled": False,
+    "last_started_at": 0.0,
+    "last_stopped_at": 0.0,
+}
 
 _thread_data = threading.local()
 _orig_sleep = time.sleep
@@ -84,6 +92,430 @@ def clear_sticky_domain():
 
 def set_last_email(email: str):
     _thread_data.last_attempt_email = email
+
+
+def _set_last_domain_failure_event(domain: str, reason: str) -> None:
+    normalized = _normalize_main_domain(domain)
+    normalized_reason = str(reason or "").strip().lower()
+    if not normalized or normalized_reason not in _MAIL_DOMAIN_FAILURE_TYPES:
+        return
+    _thread_data.last_domain_failure_event = {
+        "domain": normalized,
+        "reason": normalized_reason,
+    }
+
+
+def pop_last_domain_failure_event() -> dict:
+    event = getattr(_thread_data, 'last_domain_failure_event', None)
+    _thread_data.last_domain_failure_event = None
+    return dict(event) if isinstance(event, dict) else {}
+
+
+def _get_configured_main_domains() -> list[str]:
+    seen = set()
+    domains = []
+    for part in str(getattr(cfg, 'MAIL_DOMAINS', '') or '').split(','):
+        root = str(part or '').strip().lower().strip('.')
+        if root and root not in seen:
+            seen.add(root)
+            domains.append(root)
+    return domains
+
+
+def _normalize_main_domain(domain: str) -> str:
+    text = str(domain or "").strip().lower().strip(".")
+    if not text:
+        return ""
+    if "@" in text:
+        _, text = text.rsplit("@", 1)
+        text = text.strip().strip(".")
+        if not text:
+            return ""
+
+    configured = _get_configured_main_domains()
+    for root in configured:
+        if text == root or text.endswith(f".{root}"):
+            return root
+    return text if not configured else ""
+
+
+def _get_disabled_main_domains() -> set[str]:
+    normalized = set()
+    for domain in getattr(cfg, 'DISABLED_MAIL_DOMAINS', []) or []:
+        root = _normalize_main_domain(domain)
+        if root:
+            normalized.add(root)
+    return normalized
+
+
+def _all_configured_main_domains_disabled() -> bool:
+    configured = _get_configured_main_domains()
+    if not configured:
+        return False
+    disabled = _get_disabled_main_domains()
+    return bool(disabled) and all(domain in disabled for domain in configured)
+
+
+def is_mail_domain_disabled(domain: str) -> bool:
+    normalized = _normalize_main_domain(domain)
+    return bool(normalized) and normalized in _get_disabled_main_domains()
+
+
+def is_mail_domain_runtime_control_enabled(mode: str | None = None) -> bool:
+    current_mode = str(mode or getattr(cfg, 'EMAIL_API_MODE', '') or '').strip()
+    if current_mode not in {"cloudflare_temp_email", "freemail", "cloudmail", "openai_cpa"}:
+        return False
+    return bool(getattr(cfg, 'ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL', False))
+
+
+def start_mail_domain_runtime_tracking() -> None:
+    if not is_mail_domain_runtime_control_enabled():
+        return
+    now = time.time()
+    with _DOMAIN_RUNTIME_LOCK:
+        _DOMAIN_RUNTIME_SESSION["counting_enabled"] = True
+        _DOMAIN_RUNTIME_SESSION["last_started_at"] = now
+        _DOMAIN_RUNTIME_SESSION["last_stopped_at"] = 0.0
+
+
+def stop_mail_domain_runtime_tracking() -> None:
+    now = time.time()
+    with _DOMAIN_RUNTIME_LOCK:
+        _DOMAIN_RUNTIME_SESSION["counting_enabled"] = False
+        _DOMAIN_RUNTIME_SESSION["last_stopped_at"] = now
+
+
+def clear_mail_domain_runtime_stats() -> None:
+    with _DOMAIN_RUNTIME_LOCK:
+        _DOMAIN_RUNTIME_STATE.clear()
+        _DOMAIN_RUNTIME_SESSION["counting_enabled"] = False
+        _DOMAIN_RUNTIME_SESSION["last_started_at"] = 0.0
+        _DOMAIN_RUNTIME_SESSION["last_stopped_at"] = 0.0
+
+
+def _is_mail_domain_runtime_tracking_active() -> bool:
+    return bool(_DOMAIN_RUNTIME_SESSION.get("counting_enabled"))
+
+
+def _new_domain_runtime_state() -> dict:
+    return {
+        "fail_count": 0,
+        "success_count": 0,
+        "failure_counts": {},
+        "last_failure_reason": "",
+        "cooldown_until": 0.0,
+        "cooldown_reason": "",
+        "last_used_at": 0.0,
+        "last_failure_at": 0.0,
+        "last_success_at": 0.0,
+    }
+
+
+def _prune_expired_domain_records(now: float) -> None:
+    expired_domains = [
+        domain for domain, state in _DOMAIN_RUNTIME_STATE.items()
+        if float(state.get("cooldown_until") or 0.0) > 0 and float(state.get("cooldown_until") or 0.0) <= now
+    ]
+    for domain in expired_domains:
+        _DOMAIN_RUNTIME_STATE.pop(domain, None)
+
+
+def _get_domain_state(domain: str) -> dict:
+    now = time.time()
+    normalized = _normalize_main_domain(domain)
+    if not normalized or not is_mail_domain_runtime_control_enabled():
+        return {}
+
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+        return dict(state)
+
+
+def pick_available_main_domain(main_domains: list[str]) -> str | None:
+    disabled_domains = _get_disabled_main_domains()
+    if not is_mail_domain_runtime_control_enabled():
+        normalized_domains = [_normalize_main_domain(domain) for domain in main_domains]
+        candidates = [domain for domain in normalized_domains if domain and domain not in disabled_domains]
+        return random.choice(candidates) if candidates else None
+
+    candidates = []
+    now = time.time()
+
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        for domain in main_domains:
+            normalized = _normalize_main_domain(domain)
+            if not normalized or normalized in disabled_domains:
+                continue
+            state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+            cooldown_until = float(state.get("cooldown_until") or 0.0)
+            if cooldown_until > now:
+                continue
+            candidates.append(normalized)
+
+        if not candidates:
+            return None
+
+        selected = random.choice(candidates)
+        _DOMAIN_RUNTIME_STATE[selected]["last_used_at"] = now
+        return selected
+
+
+def _apply_domain_cooldown(state: dict, reason: str, cooldown_sec: int) -> float:
+    cooldown_until = time.time() + max(int(cooldown_sec or 0), 0)
+    state["fail_count"] = 0
+    state["cooldown_reason"] = reason
+    state["cooldown_until"] = cooldown_until
+    return cooldown_until
+
+
+def _get_selected_mail_domain_failure_types() -> set[str]:
+    selected = {
+        str(item or "").strip().lower()
+        for item in (getattr(cfg, 'MAIL_DOMAIN_FAILURE_TYPES', []) or [])
+        if str(item or "").strip()
+    }
+    return {item for item in selected if item in _MAIL_DOMAIN_FAILURE_TYPES}
+
+
+def _recalculate_domain_fail_count(state: dict) -> int:
+    failure_counts = state.get("failure_counts")
+    if not isinstance(failure_counts, dict):
+        failure_counts = {}
+        state["failure_counts"] = failure_counts
+    selected = _get_selected_mail_domain_failure_types()
+    fail_count = sum(
+        max(0, int(failure_counts.get(reason) or 0))
+        for reason in selected
+    )
+    state["fail_count"] = fail_count
+    return fail_count
+
+
+def _build_domain_result(domain: str, state: dict, cooldown_until: float, cooldown_triggered: bool) -> dict:
+    return {
+        "domain": domain,
+        "fail_count": int(state.get("fail_count") or 0),
+        "success_count": int(state.get("success_count") or 0),
+        "failure_counts": dict(state.get("failure_counts") or {}),
+        "last_failure_reason": str(state.get("last_failure_reason") or ""),
+        "cooldown_reason": str(state.get("cooldown_reason") or ""),
+        "cooldown_until": cooldown_until,
+        "cooldown_triggered": cooldown_triggered,
+    }
+
+
+def record_domain_failure(domain: str, reason: str) -> dict:
+    normalized = _normalize_main_domain(domain)
+    normalized_reason = str(reason or "").strip().lower()
+    if (
+        not normalized
+        or normalized_reason not in _MAIL_DOMAIN_FAILURE_TYPES
+        or not is_mail_domain_runtime_control_enabled()
+        or not _is_mail_domain_runtime_tracking_active()
+    ):
+        return {}
+
+    threshold = int(getattr(cfg, 'MAIL_DOMAIN_FAIL_THRESHOLD', 0) or 0)
+    cooldown_sec = int(getattr(cfg, 'MAIL_DOMAIN_FAIL_COOLDOWN_SEC', 0) or 0)
+    now = time.time()
+
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+        failure_counts = state.get("failure_counts")
+        if not isinstance(failure_counts, dict):
+            failure_counts = {}
+            state["failure_counts"] = failure_counts
+        cooldown_until = float(state.get("cooldown_until") or 0.0)
+        state["last_failure_at"] = now
+        state["last_failure_reason"] = normalized_reason
+
+        if cooldown_until > now:
+            _recalculate_domain_fail_count(state)
+            state["fail_count"] = 0
+            if not state.get("cooldown_reason"):
+                state["cooldown_reason"] = normalized_reason
+            return _build_domain_result(normalized, state, cooldown_until, False)
+
+        failure_counts[normalized_reason] = int(failure_counts.get(normalized_reason) or 0) + 1
+        fail_count = _recalculate_domain_fail_count(state)
+        cooldown_triggered = False
+        if threshold > 0 and fail_count >= threshold:
+            cooldown_until = _apply_domain_cooldown(state, normalized_reason, cooldown_sec)
+            cooldown_triggered = True
+        else:
+            cooldown_until = float(state.get("cooldown_until") or 0.0)
+        return _build_domain_result(normalized, state, cooldown_until, cooldown_triggered)
+
+
+def record_domain_success(domain: str) -> dict:
+    normalized = _normalize_main_domain(domain)
+    if not normalized or not is_mail_domain_runtime_control_enabled() or not _is_mail_domain_runtime_tracking_active():
+        return {}
+
+    now = time.time()
+
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+        state["success_count"] = int(state.get("success_count") or 0) + 1
+        state["last_success_at"] = now
+        _recalculate_domain_fail_count(state)
+        cooldown_until = float(state.get("cooldown_until") or 0.0)
+        return _build_domain_result(normalized, state, cooldown_until, False)
+
+
+def _build_domain_runtime_row(domain: str, state: dict, now: float) -> dict:
+    cooldown_until = float(state.get("cooldown_until") or 0.0)
+    is_disabled = is_mail_domain_disabled(domain)
+    _recalculate_domain_fail_count(state)
+    return {
+        "domain": domain,
+        "fail_count": int(state.get("fail_count") or 0),
+        "success_count": int(state.get("success_count") or 0),
+        "failure_counts": dict(state.get("failure_counts") or {}),
+        "last_failure_reason": str(state.get("last_failure_reason") or ""),
+        "cooldown_until": cooldown_until,
+        "cooldown_remaining_sec": max(0, int(cooldown_until - now)) if cooldown_until > now else 0,
+        "cooldown_reason": str(state.get("cooldown_reason") or ""),
+        "is_available": cooldown_until <= now,
+        "is_disabled": is_disabled,
+        "is_enabled": not is_disabled,
+        "last_used_at": float(state.get("last_used_at") or 0.0),
+        "last_failure_at": float(state.get("last_failure_at") or 0.0),
+        "last_success_at": float(state.get("last_success_at") or 0.0),
+    }
+
+
+def _get_domain_runtime_row_locked(domain: str, now: float) -> dict:
+    state = _DOMAIN_RUNTIME_STATE.get(domain)
+    if not state:
+        return {}
+    return _build_domain_runtime_row(domain, state, now)
+
+
+def get_mail_domain_runtime_summary() -> dict:
+    if not is_mail_domain_runtime_control_enabled():
+        return {"total_count": 0, "available_count": 0, "cooldown_count": 0}
+
+    now = time.time()
+    configured_domains = _get_configured_main_domains()
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        cooldown_domains = {
+            domain for domain, state in _DOMAIN_RUNTIME_STATE.items()
+            if float(state.get("cooldown_until") or 0.0) > now
+        }
+        total_count = len(configured_domains)
+        cooldown_count = sum(1 for domain in configured_domains if domain in cooldown_domains)
+        available_count = max(0, total_count - cooldown_count)
+        return {
+            "total_count": total_count,
+            "available_count": available_count,
+            "cooldown_count": cooldown_count,
+        }
+
+
+def sync_mail_domain_runtime_state_with_config() -> dict:
+    configured_domains = _get_configured_main_domains()
+    configured_set = set(configured_domains)
+    now = time.time()
+
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        existing_domains = set(_DOMAIN_RUNTIME_STATE.keys())
+
+        added_count = 0
+        removed_count = 0
+
+        for domain in configured_domains:
+            if domain not in _DOMAIN_RUNTIME_STATE:
+                _DOMAIN_RUNTIME_STATE[domain] = _new_domain_runtime_state()
+                added_count += 1
+
+        for domain in list(existing_domains):
+            if domain not in configured_set:
+                _DOMAIN_RUNTIME_STATE.pop(domain, None)
+                removed_count += 1
+
+        total_count = len(_DOMAIN_RUNTIME_STATE)
+
+    return {
+        "added_count": added_count,
+        "removed_count": removed_count,
+        "total_count": total_count,
+    }
+
+
+def clear_mail_domain_runtime_domain_counters(domain: str) -> dict:
+    normalized = _normalize_main_domain(domain)
+    if not normalized or not is_mail_domain_runtime_control_enabled():
+        return {}
+
+    now = time.time()
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        state = _DOMAIN_RUNTIME_STATE.get(normalized)
+        if not state:
+            return {}
+        state["fail_count"] = 0
+        state["success_count"] = 0
+        state["failure_counts"] = {}
+        state["last_failure_reason"] = ""
+        state["last_failure_at"] = 0.0
+        state["last_success_at"] = 0.0
+        return _get_domain_runtime_row_locked(normalized, now)
+
+
+def clear_mail_domain_runtime_domain_cooldown(domain: str) -> dict:
+    normalized = _normalize_main_domain(domain)
+    if not normalized or not is_mail_domain_runtime_control_enabled():
+        return {}
+
+    now = time.time()
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        state = _DOMAIN_RUNTIME_STATE.get(normalized)
+        if not state:
+            return {}
+        state["cooldown_until"] = 0.0
+        state["cooldown_reason"] = ""
+        return _get_domain_runtime_row_locked(normalized, now)
+
+
+def clear_all_mail_domain_runtime_cooldowns() -> int:
+    if not is_mail_domain_runtime_control_enabled():
+        return 0
+
+    now = time.time()
+    cleared_count = 0
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        for state in _DOMAIN_RUNTIME_STATE.values():
+            if float(state.get("cooldown_until") or 0.0) > now:
+                cleared_count += 1
+            state["cooldown_until"] = 0.0
+            state["cooldown_reason"] = ""
+            _recalculate_domain_fail_count(state)
+    return cleared_count
+
+
+def get_mail_domain_runtime_stats() -> list[dict]:
+    if not is_mail_domain_runtime_control_enabled():
+        return []
+
+    sync_mail_domain_runtime_state_with_config()
+    now = time.time()
+    rows = []
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        for domain in sorted(_DOMAIN_RUNTIME_STATE.keys()):
+            state = _DOMAIN_RUNTIME_STATE[domain]
+            rows.append(_build_domain_runtime_row(domain, state, now))
+    return rows
+
 
 
 def get_last_email() -> Optional[str]:
@@ -210,6 +642,7 @@ def get_email_and_token(proxies: Any = None) -> tuple:
     """兼容五种邮箱模式的地址创建，返回 (email, token_or_id)。"""
     if getattr(cfg, 'GLOBAL_STOP', False): return None, None
     _thread_data.last_attempt_email = None
+    _thread_data.last_domain_failure_event = None
 
     mode = cfg.EMAIL_API_MODE
     mail_proxies = proxies if cfg.USE_PROXY_FOR_EMAIL else None
@@ -491,6 +924,7 @@ def get_email_and_token(proxies: Any = None) -> tuple:
         return target_email, json.dumps(mailbox_info, ensure_ascii=False)
 
     prefix, ai_enabled = _get_ai_data_package()
+    use_domain_runtime_control = is_mail_domain_runtime_control_enabled(mode)
 
     if cfg.ENABLE_SUB_DOMAINS:
         # sticky = getattr(_thread_data, 'sticky_domain', None)
@@ -503,7 +937,15 @@ def get_email_and_token(proxies: Any = None) -> tuple:
             print(f"[{cfg.ts()}] [ERROR] 未配置主域名池，无法捏造子域！")
             return None, None
 
-        selected_main = random.choice(main_list)
+        selected_main = pick_available_main_domain(main_list)
+        if not selected_main:
+            if _all_configured_main_domains_disabled():
+                print(f"[{cfg.ts()}] [ERROR] 所有主域名均已被手动禁用，当前无法继续生成邮箱！")
+            elif use_domain_runtime_control:
+                print(f"[{cfg.ts()}] [ERROR] 所有主域名均处于冷却中，当前无法继续生成邮箱！")
+            else:
+                print(f"[{cfg.ts()}] [ERROR] 未找到可用主域名，当前无法继续生成邮箱！")
+            return None, None
         if getattr(cfg, 'RANDOM_SUB_DOMAIN_LEVEL', False):
             level = random.randint(1, 7)
         else:
@@ -527,7 +969,15 @@ def get_email_and_token(proxies: Any = None) -> tuple:
         if not domain_list:
             print(f"[{cfg.ts()}] [ERROR] 域名池配置为空，无法生成邮箱！")
             return None, None
-        selected_domain = random.choice(domain_list)
+        selected_domain = pick_available_main_domain(domain_list)
+        if not selected_domain:
+            if _all_configured_main_domains_disabled():
+                print(f"[{cfg.ts()}] [ERROR] 所有主域名均已被手动禁用，当前无法继续生成邮箱！")
+            elif use_domain_runtime_control:
+                print(f"[{cfg.ts()}] [ERROR] 所有主域名均处于冷却中，当前无法继续生成邮箱！")
+            else:
+                print(f"[{cfg.ts()}] [ERROR] 域名池配置为空或无有效主域名，无法生成邮箱！")
+            return None, None
 
     email_str = f"{prefix}@{selected_domain}"
     set_last_email(email_str)
@@ -602,6 +1052,7 @@ def get_email_and_token(proxies: Any = None) -> tuple:
     if mode == "cloudflare_temp_email":
         headers = {"x-admin-auth": cfg.ADMIN_AUTH, "Content-Type": "application/json"}
         body = {"enablePrefix": False, "name": prefix, "domain": selected_domain}
+        terminal_failure_reason = ""
         for attempt in range(5):
             if getattr(cfg, 'GLOBAL_STOP', False): return None, None
             try:
@@ -610,6 +1061,14 @@ def get_email_and_token(proxies: Any = None) -> tuple:
                     headers=headers, json=body,
                     proxies=mail_proxies, verify=_ssl_verify(), timeout=15,
                 )
+                status_code = int(getattr(res, 'status_code', 0) or 0)
+                text = str(getattr(res, 'text', '') or '')
+                quota_text = text.lower()
+                if status_code in {403, 429, 507} or any(token in quota_text for token in ("quota", "limit", "capacity", "exceeded", "over limit", "full")):
+                    terminal_failure_reason = "capacity_exceeded"
+                    print(f"[{cfg.ts()}] [WARNING] cloudflare_temp_email邮箱容量疑似超限 (尝试 {attempt + 1}/5): {res.text}")
+                    time.sleep(1)
+                    continue
                 res.raise_for_status()
                 data = res.json()
                 if data and data.get("address"):
@@ -618,11 +1077,15 @@ def get_email_and_token(proxies: Any = None) -> tuple:
                     set_last_email(email)
                     print(f"[{cfg.ts()}] [INFO] cloudflare_temp_email成功获取临时邮箱: {mask_email(email)}")
                     return email, jwt
+                terminal_failure_reason = "cloudflare_temp_email_network"
                 print(f"[{cfg.ts()}] [WARNING] cloudflare_temp_email邮箱申请失败 (尝试 {attempt + 1}/5): {res.text}")
                 time.sleep(1)
             except Exception as e:
+                terminal_failure_reason = "cloudflare_temp_email_network"
                 print(f"[{cfg.ts()}] [ERROR] cloudflare_temp_email邮箱注册网络异常，准备重试: {e}")
                 time.sleep(2)
+        if terminal_failure_reason:
+            _set_last_domain_failure_event(selected_domain, terminal_failure_reason)
         return None, None
 
 

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 from utils import core_engine, db_manager
 from utils.config import reload_all_configs
 from utils.log_stream_cache import RecentParsedLogCache
+from utils.email_providers import mail_service
 
 from global_state import engine, log_history, append_log
 from routers import api_routes
@@ -72,6 +73,7 @@ def _worker_push_thread():
         except: pass
         args = DummyArgs(proxy=getattr(core_engine.cfg, 'DEFAULT_PROXY', None))
         core_engine.run_stats.update({"success": 0, "failed": 0, "retries": 0, "pwd_blocked": 0, "phone_verify": 0, "start_time": time.time()})
+        mail_service.start_mail_domain_runtime_tracking()
         if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False): engine.start_cpa(args)
         elif getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False): engine.start_sub2api(args)
         else: engine.start_normal(args)
@@ -162,6 +164,7 @@ def _worker_push_thread():
                                 threading.Thread(target=_internal_start, daemon=True).start()
                             elif cmd == "stop" and is_running:
                                 engine.stop()
+                                mail_service.stop_mail_domain_runtime_tracking()
                             elif cmd == "export_accounts":
                                 print(f"[{core_engine.ts()}] [系统] 收到总控提取指令，准备发货！")
                                 def _upload_task():


### PR DESCRIPTION
## 变更摘要
- 新增邮箱域名运行时控制能力，支持启用/关闭、域名禁用与冷却管理
- 补充前后端对域名运行时状态的查看、清理和同步能力
- 完善异常统计与失败归因，覆盖 discarded email 及临时邮箱相关失败场景
- 增加邮箱配置页中对应的运行时控制面板与状态展示

## 说明
- 该分支从 upstream 的 v14.2.4 tag 整理而来，用于向当前 upstream/main 发起可合并 PR
- 本次改动主要聚焦于邮箱域名运行时控制流程及相关前后端联动

## 测试情况
- [x] 邮箱配置页面可以正常打开
- [x] 域名运行时控制面板可以正常显示
- [x] 域名运行时统计信息可以正常加载
- [x] 启动 / 停止相关流程未发现明显异常
- [x] 相关 Python 文件语法检查通过
- [x] 前端脚本语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)