### PR TITLE
增加内存预测

### DIFF
--- a/index.html
+++ b/index.html
@@ -926,7 +926,7 @@
                                                             <div>
                                                                 <div class="text-sm font-black text-slate-800 break-all">{{ item.domain }}</div>
                                                                 <div class="text-[11px] text-slate-400 mt-1">
-                                                                    最近使用: {{ item.last_used_at ? new Date(item.last_used_at * 1000).toLocaleString('zh-CN', { hour12: false }) : '未使用' }}
+                                                        最近使用: {{ item.last_used_at ? formatMainlandDateTime(new Date(item.last_used_at * 1000)) : '未使用' }}
                                                                 </div>
                                                                 <div v-if="isMailDomainRuntimePristine(item)" class="text-[11px] text-sky-500 mt-1 font-medium">
                                                                     尚未参与运行，等待首次分配。
@@ -3628,6 +3628,69 @@
                             </div>
                         </div>
                         <div v-show="currentTab === 'concurrency'" v-if="config" class="grid grid-cols-1 lg:grid-cols-2 gap-5 md:gap-8">
+                            <div class="bg-white p-6 md:p-8 rounded-2xl shadow-sm hover:shadow-md transition-shadow duration-300 border border-slate-200/60 border-t-8 border-t-cyan-500 bg-gradient-to-br from-cyan-50/30 to-white lg:col-span-2">
+                                <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6">
+                                    <div>
+                                        <h3 class="text-lg md:text-xl font-black text-cyan-700 flex items-center gap-2 tracking-tight">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 7h10v10H7z"></path></svg>
+                                            内存预测与实测监控
+                                        </h3>
+                                        <p class="text-xs text-slate-500 font-medium mt-2">根据当前配置估算低/中/高内存占用，并通过 psutil 显示当前 Python 进程 RSS。</p>
+                                    </div>
+                                    <button @click="fetchMemoryPrediction" :disabled="isLoadingMemoryPrediction" class="px-4 py-2.5 rounded-xl bg-cyan-600 text-white text-sm font-black shadow-md shadow-cyan-500/20 hover:bg-cyan-700 active:scale-95 disabled:opacity-60 disabled:cursor-wait transition-all flex items-center justify-center gap-2">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" :class="{'animate-spin': isLoadingMemoryPrediction}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
+                                        重新估算
+                                    </button>
+                                </div>
+
+                                <div v-if="memoryPredictionError" class="mb-5 p-4 rounded-xl bg-rose-50 border border-rose-200 text-rose-700 text-sm font-bold">
+                                    {{ memoryPredictionError }}
+                                </div>
+
+                                <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+                                    <div class="bg-white p-4 rounded-xl border border-cyan-100 shadow-sm">
+                                        <div class="text-[11px] text-slate-500 font-black uppercase tracking-wider mb-2">当前 RSS</div>
+                                        <div class="text-2xl font-black text-cyan-700">{{ formatMemoryMb(memoryPrediction?.actual?.rss_mb ?? stats.memory?.rss_mb) }}</div>
+                                    </div>
+                                    <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm">
+                                        <div class="text-[11px] text-slate-500 font-black uppercase tracking-wider mb-2">预测中标</div>
+                                        <div class="text-2xl font-black text-slate-700">{{ formatMemoryMb(memoryPrediction?.prediction?.predicted_mb?.mid ?? stats.memory?.predicted_mid_mb) }}</div>
+                                    </div>
+                                    <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm">
+                                        <div class="text-[11px] text-slate-500 font-black uppercase tracking-wider mb-2">预测高标</div>
+                                        <div class="text-2xl font-black text-slate-700">{{ formatMemoryMb(memoryPrediction?.prediction?.predicted_mb?.high ?? stats.memory?.predicted_high_mb) }}</div>
+                                    </div>
+                                    <div class="bg-white p-4 rounded-xl border shadow-sm" :class="memorySafetyClass(memoryPrediction?.safety?.level ?? stats.memory?.safety_level)">
+                                        <div class="text-[11px] font-black uppercase tracking-wider mb-2 opacity-70">安全状态</div>
+                                        <div class="text-2xl font-black">{{ memoryPrediction?.safety?.label ?? stats.memory?.safety_label ?? '无数据' }}</div>
+                                    </div>
+                                </div>
+
+                                <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
+                                    <div class="lg:col-span-2 bg-slate-50/80 p-5 rounded-2xl border border-slate-200 shadow-inner">
+                                        <div class="text-xs font-black text-slate-600 uppercase tracking-wider mb-4">预测分解</div>
+                                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+                                            <div class="bg-white rounded-xl p-3 border border-slate-200"><span class="block text-[10px] text-slate-400 font-black uppercase mb-1">低标</span><span class="font-black text-slate-700">{{ formatMemoryMb(memoryPrediction?.prediction?.predicted_mb?.low) }}</span></div>
+                                            <div class="bg-white rounded-xl p-3 border border-slate-200"><span class="block text-[10px] text-slate-400 font-black uppercase mb-1">中标</span><span class="font-black text-slate-700">{{ formatMemoryMb(memoryPrediction?.prediction?.predicted_mb?.mid) }}</span></div>
+                                            <div class="bg-white rounded-xl p-3 border border-slate-200"><span class="block text-[10px] text-slate-400 font-black uppercase mb-1">高标</span><span class="font-black text-slate-700">{{ formatMemoryMb(memoryPrediction?.prediction?.predicted_mb?.high) }}</span></div>
+                                        </div>
+                                        <p class="text-xs text-slate-500 leading-relaxed font-medium">{{ memoryPrediction?.safety?.message || memoryPrediction?.prediction?.model_note || '切换到本页后会自动获取完整预测数据。' }}</p>
+                                        <p v-if="memoryPrediction?.actual?.note" class="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mt-3 font-bold">{{ memoryPrediction.actual.note }}</p>
+                                    </div>
+                                    <div class="bg-white p-5 rounded-2xl border border-slate-200 shadow-sm">
+                                        <div class="text-xs font-black text-slate-600 uppercase tracking-wider mb-4">配置快照</div>
+                                        <div class="space-y-2 text-xs font-bold text-slate-600">
+                                            <div class="flex justify-between gap-3"><span>REG Threads</span><span class="text-cyan-700">{{ memoryPrediction?.prediction?.config_snapshot?.reg_threads ?? config.reg_threads }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>CPA Threads</span><span class="text-cyan-700">{{ memoryPrediction?.prediction?.config_snapshot?.cpa_threads ?? config.cpa_mode?.threads }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>Sub2API Threads</span><span class="text-cyan-700">{{ memoryPrediction?.prediction?.config_snapshot?.sub2api_threads ?? config.sub2api_mode?.threads }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>Proxy Pool</span><span class="text-cyan-700">{{ memoryPrediction?.prediction?.config_snapshot?.proxy_pool_size ?? 'N/A' }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>Max Logs</span><span class="text-cyan-700">{{ memoryPrediction?.prediction?.config_snapshot?.max_log_lines ?? config.max_log_lines }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>DB Type</span><span class="text-cyan-700 uppercase">{{ memoryPrediction?.prediction?.config_snapshot?.db_type ?? config.database?.type }}</span></div>
+                                            <div class="flex justify-between gap-3"><span>系统使用率</span><span class="text-cyan-700">{{ memoryPrediction?.actual?.system_used_percent ?? 'N/A' }}%</span></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="bg-white p-6 md:p-8 rounded-2xl shadow-sm hover:shadow-md transition-shadow duration-300 border border-slate-200/60 border-t-8 border-t-indigo-500 bg-gradient-to-br from-indigo-50/20 to-white lg:col-span-2">
                                 <h3 class="text-lg md:text-xl font-black text-indigo-700 mb-6 flex items-center gap-2 tracking-tight"><svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7c0-1.105 3.582-2 8-2s8 .895 8 2-3.582 2-8 2-8-.895-8-2zm0 5c0 1.105 3.582 2 8 2s8-.895 8-2m-16 5c0 1.105 3.582 2 8 2s8-.895 8-2"></path></svg> 数据库存储引擎 <span class="text-xs font-bold text-rose-500 bg-rose-50 px-2 py-1 rounded border border-rose-100 ml-2">修改后需点左下角重启项目后生效</span></h3>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pymysql
 cryptography
 cachetools
 dnspython
+psutil

--- a/routers/system_routes.py
+++ b/routers/system_routes.py
@@ -22,6 +22,7 @@ from utils import core_engine, db_manager
 from utils.email_providers import mail_service
 from utils.config import reload_all_configs
 from utils.integrations.tg_notifier import send_tg_msg_async
+from utils.memory_predictor import build_memory_report
 import utils.config as cfg
 
 router = APIRouter()
@@ -200,6 +201,9 @@ async def get_stats(token: str = Depends(verify_token)):
             "Sub2Api 仓管" if getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False) else "常规量产")
 
     domain_summary = mail_service.get_mail_domain_runtime_summary()
+    memory_report = build_memory_report(getattr(core_engine.cfg, '_c', {}))
+    actual_memory = memory_report.get("actual", {})
+    predicted_memory = memory_report.get("prediction", {}).get("predicted_mb", {})
 
     return {
         "success": stats["success"], "failed": stats["failed"], "retries": stats["retries"],
@@ -209,7 +213,19 @@ async def get_stats(token: str = Depends(verify_token)):
         "progress_pct": f"{progress_pct}%", "is_running": is_running, "mode": current_mode,
         "available_count": domain_summary.get("available_count", 0),
         "cooldown_count": domain_summary.get("cooldown_count", 0),
+        "memory": {
+            "rss_mb": actual_memory.get("rss_mb"),
+            "predicted_mid_mb": predicted_memory.get("mid"),
+            "predicted_high_mb": predicted_memory.get("high"),
+            "safety_level": memory_report.get("safety", {}).get("level"),
+            "safety_label": memory_report.get("safety", {}).get("label"),
+        },
     }
+
+
+@router.get("/api/system/memory_prediction")
+async def get_memory_prediction(token: str = Depends(verify_token)):
+    return build_memory_report(getattr(core_engine.cfg, '_c', {}))
 
 
 @router.post("/api/start_check")

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,32 @@
 const { createApp } = Vue;
 
+const APP_LOCALE = 'zh-CN';
+const APP_TIME_ZONE = 'Asia/Shanghai';
+
+function formatMainlandDateTime(date, options = {}) {
+    return new Intl.DateTimeFormat(APP_LOCALE, {
+        timeZone: APP_TIME_ZONE,
+        hour12: false,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        ...options
+    }).format(date).replace(/\//g, '-');
+}
+
+function formatMainlandTime(date) {
+    return new Intl.DateTimeFormat(APP_LOCALE, {
+        timeZone: APP_TIME_ZONE,
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+    }).format(date);
+}
+
 function normalizeBooleanLike(value, defaultValue = false) {
     if (value === true || value === false) {
         return value;
@@ -92,8 +119,12 @@ createApp({
                 success: 0, failed: 0, retries: 0, total: 0, target: 0,
                 pwd_blocked: 0, phone_verify: 0,
                 success_rate: '0.0%', elapsed: '0.0s', avg_time: '0.0s', progress_pct: '0%',
-                mode: '未启动'
+                mode: '未启动',
+                memory: { rss_mb: null, predicted_mid_mb: null, predicted_high_mb: null, safety_level: 'unknown', safety_label: '无数据' }
             },
+            memoryPrediction: null,
+            isLoadingMemoryPrediction: false,
+            memoryPredictionError: '',
             inventoryStats: {
                 local: { total: 0, active: 0, disabled: 0 },
                 cloud: { total: 0, cpa: 0, sub2api: 0, enabled: 0 }
@@ -351,6 +382,47 @@ createApp({
             return res;
         },
 
+        formatMemoryMb(value) {
+            if (value === null || value === undefined || value === '') return 'N/A';
+            const numeric = Number(value);
+            if (Number.isNaN(numeric)) return 'N/A';
+            return `${numeric.toFixed(1)} MB`;
+        },
+
+        formatMainlandDateTime(date, options = {}) {
+            return formatMainlandDateTime(date, options);
+        },
+
+        memorySafetyClass(level) {
+            const classes = {
+                ok: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+                watch: 'bg-sky-50 text-sky-700 border-sky-200',
+                warning: 'bg-amber-50 text-amber-700 border-amber-200',
+                critical: 'bg-rose-50 text-rose-700 border-rose-200',
+                unknown: 'bg-slate-50 text-slate-600 border-slate-200'
+            };
+            return classes[level] || classes.unknown;
+        },
+
+        async fetchMemoryPrediction() {
+            if (!this.isLoggedIn) return;
+            this.isLoadingMemoryPrediction = true;
+            this.memoryPredictionError = '';
+            try {
+                const res = await this.authFetch('/api/system/memory_prediction');
+                const data = await res.json();
+                if (data.status === 'success') {
+                    this.memoryPrediction = data;
+                } else {
+                    this.memoryPredictionError = data.message || '内存预测数据获取失败';
+                }
+            } catch (e) {
+                this.memoryPredictionError = '内存预测 API 请求失败';
+            } finally {
+                this.isLoadingMemoryPrediction = false;
+            }
+        },
+
         async handleLogin() {
             if(!this.loginPassword) { this.showToast("请输入密码！", "warning"); return; }
             try {
@@ -403,6 +475,9 @@ createApp({
             }
             if (this.currentTab === 'proxy') {
                 this.fetchClashPool();
+            }
+            if (this.currentTab === 'concurrency') {
+                this.fetchMemoryPrediction();
             }
         },
         startStatsPolling() {
@@ -922,6 +997,9 @@ createApp({
             if (tabId === 'proxy') {
                 this.fetchClashPool();
             }
+            if (tabId === 'concurrency') {
+                this.fetchMemoryPrediction();
+            }
             if (tabId === 'team_accounts') {
                 this.fetchTeamAccounts();
             }
@@ -1103,7 +1181,7 @@ createApp({
                             const checkData = await checkRes.json();
                             if (!checkData.online) {
                                 const now = new Date();
-                                const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(now);
                                 this.showToast(`🚫 启动失败：节点 [${localId}] 未连接或已掉线！`, "error");
                                 this.logs.push({
                                     parsed: true,
@@ -1160,7 +1238,7 @@ createApp({
                 this.isRunning = false;
                 await this.fetchMailDomainRuntimeStats();
                 const now = new Date();
-                const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false }); // 获取如 14:30:05 格式
+            const timeStr = formatMainlandTime(now); // 获取如 14:30:05 格式
                 this.logs.push({
                     parsed: true,
                     time: timeStr,
@@ -1982,8 +2060,7 @@ createApp({
             }
             const d = new Date(utcStr);
             if (isNaN(d.getTime())) return dateStr;
-            const pad = (n) => n.toString().padStart(2, '0');
-            return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+            return formatMainlandDateTime(d);
         },
         async exportSub2Api() {
             if (this.selectedAccounts.length === 0) {
@@ -2151,7 +2228,7 @@ createApp({
 
                 if (action === 'check') {
                     this.currentTab = 'console';
-                    const now = new Date().toLocaleString('zh-CN', { hour12: false });
+            const now = formatMainlandDateTime(new Date());
                     this.localCheckTimes[acc.id] = now;
                     acc.last_check = now;
 
@@ -2218,7 +2295,7 @@ createApp({
                     });
                 }
                 if (action === 'check') {
-                    const now = new Date().toLocaleString('zh-CN', { hour12: false });
+            const now = formatMainlandDateTime(new Date());
                     this.selectedCloud.forEach(c => { this.localCheckTimes[c.id] = now; });
                 }
 
@@ -2345,7 +2422,7 @@ createApp({
                     return;
                 }
                 const now = new Date();
-                const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(now);
 
                 if (data.status !== 'success') {
                     this.logs.push({ parsed: true, time: timeStr, level: '总控', text: `任务生成失败: ${data.message}`, raw: `[${timeStr}] [总控] 任务生成失败: ${data.message}` });
@@ -2382,7 +2459,7 @@ createApp({
 
             } catch (error) {
                 const now = new Date();
-                const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(now);
                 this.logs.push({ parsed: true, time: timeStr, level: '总控', text: `下发任务异常: ${error.message}`, raw: `[${timeStr}] [总控] 下发任务异常: ${error.message}` });
             }
         },
@@ -2416,7 +2493,7 @@ createApp({
 
                 if (event.data.type === "WORKER_READY") {
                     const now = new Date();
-                    const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(now);
 
                     if (this._extDetectionTimer) {
                         clearInterval(this._extDetectionTimer);
@@ -2450,7 +2527,7 @@ createApp({
 
                 if (event.data.type === "WORKER_LOG_REPLY") {
                     const now = new Date();
-                    const timeStr = now.toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(now);
                     this.logs.push({
                         parsed: true, time: timeStr, level: '节点',
                         text: event.data.log, raw: `[${timeStr}] [节点] ${event.data.log}`
@@ -2485,7 +2562,7 @@ createApp({
                             this.isRunning = false;
                             window.postMessage({ type: "CMD_STOP_WORKER" }, "*");
 
-                            const timeStr = new Date().toLocaleTimeString('zh-CN', { hour12: false });
+            const timeStr = formatMainlandTime(new Date());
                             this.logs.push({
                                 parsed: true, time: timeStr, level: '总控',
                                 text: `🛑 目标产量已达成，总控引擎已自动挂起。`,

--- a/utils/memory_predictor.py
+++ b/utils/memory_predictor.py
@@ -1,0 +1,246 @@
+"""Memory usage prediction and runtime measurement helpers.
+
+This module intentionally keeps psutil optional at import time so the web
+console can still boot in older deployments. When psutil is installed, the
+API returns actual RSS/VMS/percent information in addition to the static
+prediction model.
+"""
+
+import os
+import platform
+import sys
+import time
+from typing import Any, Dict, Iterable
+
+
+MB = 1024 * 1024
+
+
+def _to_int(value: Any, default: int = 0, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def _is_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _list_len(value: Any) -> int:
+    if isinstance(value, (list, tuple, set)):
+        return len(value)
+    if isinstance(value, str):
+        return len([item for item in value.splitlines() if item.strip()])
+    return 0
+
+
+def _get_nested(config: Dict[str, Any], *keys: str, default: Any = None) -> Any:
+    cur: Any = config
+    for key in keys:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(key, default)
+    return cur
+
+
+def _round_mb(value: float) -> float:
+    return round(float(value), 2)
+
+
+def _proxy_pool_size(config: Dict[str, Any]) -> int:
+    raw_proxy_pool = config.get("raw_proxy_pool") or {}
+    raw_enabled = _is_enabled(raw_proxy_pool.get("enable"))
+    raw_count = _list_len(raw_proxy_pool.get("proxy_list"))
+    if raw_enabled and raw_count:
+        return raw_count
+
+    clash_conf = config.get("clash_proxy_pool") or {}
+    clash_enabled = _is_enabled(clash_conf.get("enable"))
+    pool_mode = _is_enabled(clash_conf.get("pool_mode"))
+    warp_count = _list_len(config.get("warp_proxy_list"))
+    if clash_enabled and pool_mode and warp_count:
+        return warp_count
+    return 1 if config.get("default_proxy") else 0
+
+
+def _mail_domain_count(config: Dict[str, Any]) -> int:
+    domains = config.get("mail_domains")
+    if isinstance(domains, str):
+        return len([item for item in domains.split(",") if item.strip()])
+    return _list_len(domains)
+
+
+def predict_memory_usage(config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Estimate low/mid/high memory usage in MB from current configuration."""
+    config = config or {}
+    os_name = platform.system() or sys.platform
+    is_windows = os_name.lower().startswith("windows")
+
+    reg_threads = _to_int(config.get("reg_threads"), 3, 1)
+    cpa_threads = _to_int(_get_nested(config, "cpa_mode", "threads", default=10), 10, 1)
+    sub2api_threads = _to_int(_get_nested(config, "sub2api_mode", "threads", default=10), 10, 1)
+    max_executor_workers = max(reg_threads, cpa_threads, sub2api_threads)
+    max_log_lines = _to_int(config.get("max_log_lines"), 500, 1)
+    proxy_pool_size = _proxy_pool_size(config)
+    mail_domain_count = _mail_domain_count(config)
+
+    enable_multi_thread = _is_enabled(config.get("enable_multi_thread_reg"))
+    enable_cpa = _is_enabled(_get_nested(config, "cpa_mode", "enable", default=False))
+    enable_sub2api = _is_enabled(_get_nested(config, "sub2api_mode", "enable", default=False))
+    cluster_enabled = bool(str(config.get("cluster_master_url", "") or "").strip())
+    db_type = str(_get_nested(config, "database", "type", default=config.get("db_type", "sqlite")) or "sqlite").lower()
+
+    # Conservative estimates based on this FastAPI + threaded worker workload.
+    python_runtime_mb = 35.0
+    web_stack_mb = 18.0
+    db_mb = 12.0 if db_type == "mysql" else 5.0
+    config_mb = 2.0
+    log_history_mb = max(0.1, max_log_lines * 0.002)
+    cluster_mb = 6.0 if cluster_enabled else 1.0
+    proxy_mb = proxy_pool_size * 0.15
+    mail_domain_mb = mail_domain_count * 0.03
+
+    thread_stack_mb = 1.5 if is_windows else 8.0
+    worker_state_mb = 5.0
+    health_worker_mb = 2.0
+    engine_thread_mb = thread_stack_mb + 1.0
+
+    low_threads = 1
+    mid_reg_workers = reg_threads if enable_multi_thread else 1
+    mid_health_workers = cpa_threads if enable_cpa else (sub2api_threads if enable_sub2api else 0)
+    high_reg_workers = max_executor_workers
+    high_health_workers = max(cpa_threads, sub2api_threads) if (enable_cpa or enable_sub2api) else max(cpa_threads, sub2api_threads) * 0.35
+
+    base_breakdown = {
+        "python_runtime_mb": python_runtime_mb,
+        "fastapi_uvicorn_mb": web_stack_mb,
+        "database_mb": db_mb,
+        "config_mb": config_mb,
+        "log_history_mb": _round_mb(log_history_mb),
+        "cluster_mb": cluster_mb,
+        "proxy_pool_mb": _round_mb(proxy_mb),
+        "mail_domain_tracking_mb": _round_mb(mail_domain_mb),
+    }
+
+    base_total = sum(base_breakdown.values())
+
+    low = base_total + engine_thread_mb + low_threads * 1.0
+    mid = base_total + engine_thread_mb + mid_reg_workers * (thread_stack_mb + worker_state_mb) + mid_health_workers * health_worker_mb
+    high = base_total + engine_thread_mb + high_reg_workers * (thread_stack_mb + worker_state_mb) + high_health_workers * health_worker_mb + proxy_pool_size * 0.05
+
+    return {
+        "predicted_mb": {
+            "low": _round_mb(low),
+            "mid": _round_mb(mid),
+            "high": _round_mb(high),
+        },
+        "breakdown": {
+            **base_breakdown,
+            "engine_thread_mb": _round_mb(engine_thread_mb),
+            "registration_worker_mb_each": _round_mb(thread_stack_mb + worker_state_mb),
+            "health_worker_mb_each": health_worker_mb,
+        },
+        "config_snapshot": {
+            "os": os_name,
+            "enable_multi_thread_reg": enable_multi_thread,
+            "reg_threads": reg_threads,
+            "cpa_threads": cpa_threads,
+            "sub2api_threads": sub2api_threads,
+            "max_executor_workers": max_executor_workers,
+            "max_log_lines": max_log_lines,
+            "proxy_pool_size": proxy_pool_size,
+            "mail_domain_count": mail_domain_count,
+            "db_type": db_type,
+            "cluster_enabled": cluster_enabled,
+        },
+        "model_note": "估算值用於容量預警；實際 RSS 仍會因作業系統、curl/HTTP 連線、第三方套件快取而浮動。",
+    }
+
+
+def get_actual_memory_usage() -> Dict[str, Any]:
+    """Return actual process memory via psutil when available."""
+    try:
+        import psutil  # type: ignore
+    except Exception as exc:
+        return {
+            "available": False,
+            "rss_mb": None,
+            "vms_mb": None,
+            "percent": None,
+            "system_total_mb": None,
+            "system_available_mb": None,
+            "note": f"未安裝 psutil，僅提供靜態預測。請安裝 psutil 以取得實測 RSS。({exc})",
+        }
+
+    process = psutil.Process(os.getpid())
+    info = process.memory_info()
+    virtual = psutil.virtual_memory()
+    return {
+        "available": True,
+        "rss_mb": _round_mb(info.rss / MB),
+        "vms_mb": _round_mb(info.vms / MB),
+        "percent": round(process.memory_percent(), 2),
+        "system_total_mb": _round_mb(virtual.total / MB),
+        "system_available_mb": _round_mb(virtual.available / MB),
+        "system_used_percent": round(virtual.percent, 2),
+        "pid": process.pid,
+        "timestamp": time.time(),
+    }
+
+
+def estimate_safety_status(prediction: Dict[str, Any], actual: Dict[str, Any]) -> Dict[str, Any]:
+    predicted = prediction.get("predicted_mb", {}) if isinstance(prediction, dict) else {}
+    high = float(predicted.get("high") or 0)
+    mid = float(predicted.get("mid") or 0)
+    rss = actual.get("rss_mb") if isinstance(actual, dict) else None
+    system_total = actual.get("system_total_mb") if isinstance(actual, dict) else None
+
+    if rss is None:
+        return {
+            "level": "unknown",
+            "label": "無實測資料",
+            "message": "psutil 不可用，目前只能查看靜態預測。",
+        }
+
+    level = "ok"
+    label = "正常"
+    message = "目前 RSS 位於預測區間內。"
+
+    if system_total and rss > float(system_total) * 0.8:
+        level = "critical"
+        label = "危險"
+        message = "目前進程 RSS 已超過系統記憶體 80%，建議立即降低併發或重啟釋放資源。"
+    elif high and rss > high * 1.2:
+        level = "warning"
+        label = "偏高"
+        message = "目前 RSS 明顯高於高標預測，可能存在連線快取、第三方套件快取或長時間運行累積。"
+    elif mid and rss > mid:
+        level = "watch"
+        label = "觀察"
+        message = "目前 RSS 高於中標預測但仍未超出高標太多，建議持續觀察。"
+
+    return {
+        "level": level,
+        "label": label,
+        "message": message,
+        "rss_vs_high_ratio": round(rss / high, 2) if high else None,
+    }
+
+
+def build_memory_report(config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    prediction = predict_memory_usage(config or {})
+    actual = get_actual_memory_usage()
+    safety = estimate_safety_status(prediction, actual)
+    return {
+        "status": "success",
+        "prediction": prediction,
+        "actual": actual,
+        "safety": safety,
+        "timestamp": time.time(),
+    }

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -20,6 +20,7 @@ from utils import core_engine, db_manager
 from utils.config import reload_all_configs
 from utils.log_stream_cache import RecentParsedLogCache
 from utils.email_providers import mail_service
+from utils.memory_predictor import build_memory_report
 
 from global_state import engine, log_history, append_log
 from routers import api_routes
@@ -139,8 +140,19 @@ def _worker_push_thread():
                                 "elapsed": f"{elapsed}s", "avg_time": f"{round(elapsed / s['success'], 1) if s['success'] > 0 else 0}s",
                                 "progress_pct": f"{min(100, round(s['success'] / s['target'] * 100, 1)) if s['target'] > 0 else 0}%",
                                 "is_running": is_running,
-                                "mode": "CPA仓管" if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False) else ("Sub2Api" if getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False) else "常规量产")
-                            }
+                                 "mode": "CPA仓管" if getattr(core_engine.cfg, 'ENABLE_CPA_MODE', False) else ("Sub2Api" if getattr(core_engine.cfg, 'ENABLE_SUB2API_MODE', False) else "常规量产")
+                             }
+                            try:
+                                memory_report = build_memory_report(getattr(core_engine.cfg, '_c', {}))
+                                stats_payload["memory"] = {
+                                    "rss_mb": memory_report.get("actual", {}).get("rss_mb"),
+                                    "predicted_mid_mb": memory_report.get("prediction", {}).get("predicted_mb", {}).get("mid"),
+                                    "predicted_high_mb": memory_report.get("prediction", {}).get("predicted_mb", {}).get("high"),
+                                    "safety_level": memory_report.get("safety", {}).get("level"),
+                                    "safety_label": memory_report.get("safety", {}).get("label"),
+                                }
+                            except Exception:
+                                pass
 
                             _, parsed_logs, changed = log_cache.refresh(log_history)
 


### PR DESCRIPTION
## Summary
- 新增后端内存预测模块，提供静态低/中/高估算与 psutil RSS/VMS 实测。
- 在 `/api/stats` 与 `/api/system/memory_prediction` 输出内存信息，并让集群子节点上报简化内存状态。
- 在并发与系统页面添加内存监控卡片。

## Validation
- `node --check static/js/app.js`
- `py -m py_compile utils/memory_predictor.py routers/system_routes.py wfxl_openai_regst.py`