### PR TITLE
增加黄金矿工模式低异常域名优先策略

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,7 @@ email_api_mode: "cloudflare_temp_email"
 mail_domains: "domain1.com,domain2.xyz,domain3.net"
 disabled_mail_domains: []
 enable_mail_domain_runtime_control: false
+mail_domain_prefer_low_failure_mode: false
 mail_domain_failure_types:
   - discarded_email
 mail_domain_fail_threshold: 3

--- a/index.html
+++ b/index.html
@@ -873,6 +873,14 @@
                                             </div>
                                         </div>
 
+                                        <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                            <input type="checkbox" v-model="config.mail_domain_prefer_low_failure_mode" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                            <div>
+                                                <div class="text-sm font-black text-slate-700">优先低异常域名</div>
+                                                <div class="text-[11px] text-slate-400 mt-1">仅在黄金矿工模式开启时生效，优先选择异常计数更低的可用主域名；同分时优先最近较少使用的域名。</div>
+                                            </div>
+                                        </label>
+
                                         <div>
                                             <label class="block text-slate-700 text-xs font-black mb-3 uppercase tracking-wider">异常判断逻辑</label>
                                             <div class="grid grid-cols-1 md:grid-cols-3 gap-3">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -716,6 +716,8 @@ createApp({
                 )];
                 if (this.config.enable_mail_domain_runtime_control === undefined) this.config.enable_mail_domain_runtime_control = false;
                 this.config.enable_mail_domain_runtime_control = normalizeBooleanLike(this.config.enable_mail_domain_runtime_control, false);
+                if (this.config.mail_domain_prefer_low_failure_mode === undefined) this.config.mail_domain_prefer_low_failure_mode = false;
+                this.config.mail_domain_prefer_low_failure_mode = normalizeBooleanLike(this.config.mail_domain_prefer_low_failure_mode, false);
                 if (!Array.isArray(this.config.mail_domain_failure_types)) this.config.mail_domain_failure_types = ['discarded_email'];
                 this.config.mail_domain_failure_types = [...new Set(
                     this.config.mail_domain_failure_types

--- a/utils/config.py
+++ b/utils/config.py
@@ -579,6 +579,7 @@ def reload_all_configs(new_config_dict=None):
     MAIL_DOMAINS = _c.get("mail_domains", "")
     DISABLED_MAIL_DOMAINS = normalize_domain_list(_c.get("disabled_mail_domains", []))
     ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL = safe_bool(_c.get("enable_mail_domain_runtime_control", False), default=False)
+    MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE = safe_bool(_c.get("mail_domain_prefer_low_failure_mode", False), default=False)
     MAIL_DOMAIN_FAILURE_TYPES = [
         str(item or "").strip().lower()
         for item in (_c.get("mail_domain_failure_types", ["discarded_email"]) or ["discarded_email"])

--- a/utils/email_providers/mail_service.py
+++ b/utils/email_providers/mail_service.py
@@ -231,6 +231,26 @@ def _get_domain_state(domain: str) -> dict:
         state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
         return dict(state)
 
+def _select_low_failure_domain(candidates: list[str]) -> Optional[str]:
+    if not candidates:
+        return None
+
+    grouped_candidates: dict[tuple[int, float], list[str]] = {}
+    best_key: Optional[tuple[int, float]] = None
+    for domain in candidates:
+        state = _DOMAIN_RUNTIME_STATE.setdefault(domain, _new_domain_runtime_state())
+        fail_count = _recalculate_domain_fail_count(state)
+        last_used_at = float(state.get("last_used_at") or 0.0)
+        key = (fail_count, last_used_at)
+        grouped_candidates.setdefault(key, []).append(domain)
+        if best_key is None or key < best_key:
+            best_key = key
+
+    if best_key is None:
+        return None
+    return random.choice(grouped_candidates[best_key])
+
+
 def pick_available_main_domain(main_domains: list[str]) -> Optional[str]:
     disabled_domains = _get_disabled_main_domains()
     if not is_mail_domain_runtime_control_enabled():
@@ -256,7 +276,12 @@ def pick_available_main_domain(main_domains: list[str]) -> Optional[str]:
         if not candidates:
             return None
 
-        selected = random.choice(candidates)
+        if getattr(cfg, 'MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE', False):
+            selected = _select_low_failure_domain(candidates)
+        else:
+            selected = random.choice(candidates)
+        if not selected:
+            return None
         _DOMAIN_RUNTIME_STATE[selected]["last_used_at"] = now
         return selected
 


### PR DESCRIPTION
## Summary
- 为黄金矿工模式新增可选的低异常优先域名分配开关
- 在域名选择时按异常计数优先、最近较少使用优先，并保留同分随机
- 更新前端黄金矿工面板与示例配置，支持保存该新开关

## Test plan
- [x] 运行 `python -m py_compile utils/config.py utils/email_providers/mail_service.py`
- [x] 启动本地服务并确认 `http://127.0.0.1:8000` 可响应
- [x] 运行定向脚本校验低异常优先、同分按较少使用优先、冷却跳过逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)