### PR TITLE
feat: 增加黄金矿工模式域名分组与运行时优化

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,13 @@ email_api_mode: "cloudflare_temp_email"
 mail_domains: "domain1.com,domain2.xyz,domain3.net"
 disabled_mail_domains: []
 enable_mail_domain_runtime_control: false
+enable_mail_domain_grouping: false
+mail_domain_group_count: 2
+mail_domain_group_mode: "auto"
+mail_domain_group_strategy: "round_robin"
+mail_domain_groups: []
+mail_domain_pinpoint_burst_mode: false
+mail_domain_prefer_low_failure_mode: false
 mail_domain_failure_types:
   - discarded_email
 mail_domain_fail_threshold: 3

--- a/index.html
+++ b/index.html
@@ -867,18 +867,103 @@
                                     <div v-if="config.enable_mail_domain_runtime_control" class="border-t border-amber-100/60 pt-5 mt-2 space-y-5">
                                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                             <div>
-                                                <label class="block text-slate-700 text-xs font-black mb-2 uppercase tracking-wider">冷却阈值</label>
-                                                <input type="number" min="0" v-model.number="config.mail_domain_fail_threshold"
-                                                       class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
-                                                       placeholder="例如 3">
+                                                <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                    <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm font-black">冷却阈值</div>
+                                                    <input type="number" min="0" v-model.number="config.mail_domain_fail_threshold"
+                                                           class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
+                                                           placeholder="例如 3">
+                                                </div>
                                                 <p class="text-[11px] text-slate-400 mt-2 font-medium">同一主域异常达到该次数后暂停使用，0 表示关闭。</p>
                                             </div>
                                             <div>
-                                                <label class="block text-slate-700 text-xs font-black mb-2 uppercase tracking-wider">冷却秒数</label>
-                                                <input type="number" min="0" v-model.number="config.mail_domain_fail_cooldown_sec"
-                                                       class="w-full appearance-none bg-white border border-slate-200 text-slate-700 rounded-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
-                                                       placeholder="例如 600">
+                                                <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                    <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm font-black">冷却秒数</div>
+                                                    <input type="number" min="0" v-model.number="config.mail_domain_fail_cooldown_sec"
+                                                           class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
+                                                           placeholder="例如 600">
+                                                </div>
                                                 <p class="text-[11px] text-slate-400 mt-2 font-medium">触发阈值后，该主域暂停使用的时长。</p>
+                                            </div>
+                                        </div>
+
+                                        <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                            <input type="checkbox" v-model="config.mail_domain_pinpoint_burst_mode" @change="applyMailDomainModeExclusion('pinpoint')" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                            <div>
+                                                <div class="text-sm font-black text-slate-700">定点爆破</div>
+                                                <div class="text-[11px] text-slate-400 mt-1">当前批次共用同一主域，按域名顺序轮转；跳过禁用和冷却域名。与“低异常优先”“域名分组”互斥，但可同时关闭。</div>
+                                            </div>
+                                        </label>
+
+                                        <label class="flex items-start gap-3 p-3 bg-white border border-slate-200 rounded-xl shadow-sm cursor-pointer">
+                                            <input type="checkbox" v-model="config.mail_domain_prefer_low_failure_mode" @change="applyMailDomainModeExclusion('low_failure')" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                            <div>
+                                                <div class="text-sm font-black text-slate-700">低异常优先</div>
+                                                <div class="text-[11px] text-slate-400 mt-1">优先选择异常更少的可用主域；同分时优先较少使用的域名。与“定点爆破”互斥，可与“域名分组”同时开启。</div>
+                                            </div>
+                                        </label>
+
+                                        <div class="p-4 bg-white border border-slate-200 rounded-xl shadow-sm space-y-4">
+                                            <label class="flex items-start gap-3 cursor-pointer">
+                                                <input type="checkbox" v-model="config.enable_mail_domain_grouping" @change="applyMailDomainModeExclusion('grouping')" class="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30">
+                                                <div>
+                                                    <div class="text-sm font-black text-slate-700">域名分组</div>
+                                                    <div class="text-[11px] text-slate-400 mt-1">按组轮换主域；与“定点爆破”互斥，可配合“低异常优先”。</div>
+                                                </div>
+                                            </label>
+                                            <div v-if="config.enable_mail_domain_grouping" class="space-y-4 border-t border-slate-100 pt-4">
+                                                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                                    <div>
+                                                        <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                            <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm font-black">组数</div>
+                                                            <input type="number" min="1" max="10" v-model.number="config.mail_domain_group_count" @change="applyMailDomainModeConstraints()"
+                                                                   class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm"
+                                                                   placeholder="例如 2">
+                                                        </div>
+                                                        <p class="text-[11px] text-slate-400 mt-2 font-medium">最多 10 组，自动模式下不能超过有效主域数量。</p>
+                                                    </div>
+                                                    <div>
+                                                        <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                            <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm font-black">模式</div>
+                                                            <select v-model="config.mail_domain_group_mode" @change="applyMailDomainModeConstraints()"
+                                                                    class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm">
+                                                                <option value="auto">自动</option>
+                                                                <option value="manual">手动</option>
+                                                            </select>
+                                                        </div>
+                                                        <p class="text-[11px] text-slate-400 mt-2 font-medium">自动按 `mail_domains` 顺序分组；手动模式需覆盖全部主域。</p>
+                                                    </div>
+                                                    <div>
+                                                        <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                            <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm font-black">策略</div>
+                                                            <select v-model="config.mail_domain_group_strategy" @change="applyMailDomainModeConstraints()"
+                                                                    class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors shadow-sm">
+                                                                <option value="round_robin">轮转</option>
+                                                                <option value="exhaust_then_next">耗尽后切组</option>
+                                                            </select>
+                                                        </div>
+                                                        <p class="text-[11px] text-slate-400 mt-2 font-medium">轮转每轮切组；耗尽后切组会先跑完当前组。</p>
+                                                    </div>
+                                                </div>
+                                                <div v-if="config.mail_domain_group_mode === 'manual'" class="space-y-3">
+                                                    <div v-for="(_, index) in config.mail_domain_groups" :key="`mail-domain-group-${index}`">
+                                                        <div class="flex items-stretch rounded-lg shadow-sm overflow-hidden">
+                                                            <div class="flex items-center px-3 bg-slate-100 border border-r-0 border-slate-200 text-slate-500 font-mono text-sm">[{{ index + 1 }}]</div>
+                                                            <input type="text" v-model="config.mail_domain_groups[index]" @blur="normalizeMailDomainGroupInput(index)"
+                                                                   class="flex-1 appearance-none bg-white border border-slate-200 text-slate-700 font-mono rounded-r-lg py-2.5 px-3 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500 transition-colors"
+                                                                   placeholder="例如 domain1.com,domain2.xyz">
+                                                        </div>
+                                                    </div>
+                                                    <p class="text-[11px] text-slate-400 font-medium">录入格式与 `mail_domains` 一致；仅允许填写已配置主域名，且不能跨组重复。</p>
+                                                </div>
+                                                <div v-else class="space-y-3">
+                                                    <div v-if="autoMailDomainGroupsPreview.length > 0" class="space-y-3">
+                                                        <div v-for="(group, index) in autoMailDomainGroupsPreview" :key="`mail-domain-auto-group-${index}`">
+                                                            <input type="text" :value="`[${index + 1}] ${group.join(',')}`" readonly
+                                                                   class="w-full appearance-none bg-slate-100 border border-slate-200 text-slate-500 font-mono rounded-lg py-2.5 px-3 shadow-sm cursor-not-allowed">
+                                                        </div>
+                                                    </div>
+                                                    <p v-else class="text-[11px] text-amber-600 font-medium bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">请先填写有效的 `mail_domains`，且分组数量不能大于有效主域名数量。</p>
+                                                </div>
                                             </div>
                                         </div>
 
@@ -929,11 +1014,16 @@
                                                 <div v-if="mailDomainRuntimeStatsError" class="text-xs text-rose-500 font-medium bg-rose-50 border border-rose-200 rounded-xl px-4 py-4 mb-3">
                                                     {{ mailDomainRuntimeStatsError }}
                                                 </div>
-                                                <div v-if="mailDomainRuntimeStats.length > 0" class="space-y-3">
-                                                    <div v-for="item in mailDomainRuntimeStats" :key="item.domain" class="bg-white border border-slate-200 rounded-xl p-4 shadow-sm">
+                                                <div v-if="sortedMailDomainRuntimeStats.length > 0" class="space-y-3">
+                                                    <div v-for="item in sortedMailDomainRuntimeStats" :key="item.domain" class="bg-white border border-slate-200 rounded-xl p-4 shadow-sm">
                                                         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
                                                             <div>
-                                                                <div class="text-sm font-black text-slate-800 break-all">{{ item.domain }}</div>
+                                                                <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                                                    <div :class="item.is_disabled ? 'text-rose-600' : (!item.is_available ? 'text-amber-600' : 'text-slate-800')" class="text-sm font-black break-all transition-colors">
+                                                                        <span v-if="mailDomainGroupLabelMap[item.domain]" class="text-slate-500 font-mono mr-1">{{ mailDomainGroupLabelMap[item.domain] }}</span>{{ item.domain }}
+                                                                    </div>
+                                                                    <div v-if="!item.is_disabled && (item.cooldown_remaining_sec || 0) > 0" class="text-[11px] font-bold text-amber-600">冷却中 {{ formatDuration(item.cooldown_remaining_sec || 0) }}</div>
+                                                                </div>
                                                                 <div class="text-[11px] text-slate-400 mt-1">
                                                         最近使用: {{ item.last_used_at ? formatMainlandDateTime(new Date(item.last_used_at * 1000)) : '未使用' }}
                                                                 </div>
@@ -945,20 +1035,14 @@
                                                                 <button @click="toggleMailDomainDisabled(item.domain)" type="button" :class="item.is_disabled ? 'border-emerald-200 text-emerald-700 hover:bg-emerald-50' : 'border-rose-200 text-rose-600 hover:bg-rose-50'" class="px-3 py-1.5 text-[11px] font-black rounded-lg border bg-white transition-colors shadow-sm">
                                                                     {{ item.is_disabled ? '启用' : '禁用' }}
                                                                 </button>
-                                                                <button @click="clearMailDomainRuntimeRowCounters(item.domain)" type="button" class="px-3 py-1.5 text-[11px] font-black rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors shadow-sm">清空计数</button>
+                                                                <button @click="clearMailDomainRuntimeRowCounters(item.domain)" type="button" class="px-3 py-1.5 text-[11px] font-black rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors shadow-sm">清除异常</button>
                                                                 <button @click="clearMailDomainRuntimeRowCooldown(item.domain)" type="button" class="px-3 py-1.5 text-[11px] font-black rounded-lg border border-amber-200 bg-white text-amber-700 hover:bg-amber-50 transition-colors shadow-sm">清除冷却</button>
-                                                                <span :class="item.is_disabled ? 'bg-slate-200 text-slate-700 border-slate-300' : 'bg-emerald-100 text-emerald-700 border-emerald-200'" class="inline-flex items-center px-3 py-1 rounded-full text-[11px] font-black border w-max">
-                                                                    {{ item.is_disabled ? '停用' : '启用' }}
-                                                                </span>
-                                                                <span :class="item.is_available ? 'bg-emerald-100 text-emerald-700 border-emerald-200' : 'bg-amber-100 text-amber-700 border-amber-200'" class="inline-flex items-center px-3 py-1 rounded-full text-[11px] font-black border w-max">
-                                                                    {{ item.is_available ? '可用' : '冷却中' }}
-                                                                </span>
                                                             </div>
                                                         </div>
-                                                        <div class="grid grid-cols-2 lg:grid-cols-3 gap-3 text-xs font-bold text-slate-600">
-                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">异常: <span class="text-slate-800">{{ item.fail_count }}</span></div>
-                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">成功: <span class="text-slate-800">{{ item.success_count }}</span></div>
-                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">时间: <span class="text-slate-800">{{ formatDuration(item.cooldown_remaining_sec || 0) }}</span></div>
+                                                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs font-bold text-slate-600">
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">注册: <span class="text-sky-600">{{ item.pick_count || 0 }}</span></div>
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">成功: <span class="text-emerald-600">{{ item.success_count }}</span></div>
+                                                            <div class="bg-slate-50 rounded-lg px-3 py-2 border border-slate-100">异常: <span class="text-rose-600">{{ item.fail_count }}</span></div>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/routers/system_routes.py
+++ b/routers/system_routes.py
@@ -52,6 +52,88 @@ class ExtResultReq(BaseModel):
     error_type: Optional[str] = "failed"
 
 
+def _normalize_mail_domain_items(raw_value: Any) -> list[str]:
+    seen = set()
+    domains = []
+    for part in str(raw_value or "").split(','):
+        text = str(part or "").strip().lower().strip('.')
+        if text and text not in seen:
+            seen.add(text)
+            domains.append(text)
+    return domains
+
+
+def _normalize_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(value, (int, float)):
+        return value != 0
+    return False
+
+
+def _normalize_mail_domain_grouping_payload(config_data: dict) -> Optional[str]:
+    master_domains = _normalize_mail_domain_items(config_data.get("mail_domains", ""))
+    master_domain_set = set(master_domains)
+
+    config_data["enable_mail_domain_grouping"] = _normalize_bool(config_data.get("enable_mail_domain_grouping", False))
+
+    try:
+        group_count = int(config_data.get("mail_domain_group_count", 2) or 2)
+    except Exception:
+        group_count = 2
+    group_count = max(1, min(10, group_count))
+    config_data["mail_domain_group_count"] = group_count
+
+    group_mode = str(config_data.get("mail_domain_group_mode", "auto") or "auto").strip().lower()
+    if group_mode not in {"auto", "manual"}:
+        group_mode = "auto"
+    config_data["mail_domain_group_mode"] = group_mode
+
+    group_strategy = str(config_data.get("mail_domain_group_strategy", "round_robin") or "round_robin").strip().lower()
+    if group_strategy not in {"round_robin", "exhaust_then_next"}:
+        group_strategy = "round_robin"
+    config_data["mail_domain_group_strategy"] = group_strategy
+
+    raw_groups = config_data.get("mail_domain_groups", [])
+    if not isinstance(raw_groups, list):
+        raw_groups = []
+    normalized_groups = [
+        ",".join(_normalize_mail_domain_items(item))
+        for item in raw_groups[:group_count]
+    ]
+    while len(normalized_groups) < group_count:
+        normalized_groups.append("")
+    config_data["mail_domain_groups"] = normalized_groups
+
+    if config_data["enable_mail_domain_grouping"]:
+        config_data["mail_domain_pinpoint_burst_mode"] = False
+        if not master_domains:
+            return "启用域名分组前请先填写 mail_domains"
+        if group_count > len(master_domains):
+            return "分组数量不能大于有效主域名数量"
+        if group_mode == "manual":
+            assigned = []
+            assigned_set = set()
+            for index, raw_group in enumerate(normalized_groups, start=1):
+                domains = _normalize_mail_domain_items(raw_group)
+                if not domains:
+                    return f"第 {index} 组至少需要填写一个域名"
+                for domain in domains:
+                    if domain not in master_domain_set:
+                        return f"第 {index} 组存在未配置在 mail_domains 中的域名: {domain}"
+                    if domain in assigned_set:
+                        return f"域名 {domain} 不能重复出现在多个分组中"
+                    assigned.append(domain)
+                    assigned_set.add(domain)
+            if assigned_set != master_domain_set:
+                missing = [domain for domain in master_domains if domain not in assigned_set]
+                if missing:
+                    return f"手动分组未覆盖所有主域名，缺少: {', '.join(missing)}"
+    return None
+
+
 def _sanitize_local_microsoft_config(local_ms: Any) -> dict:
     data = dict(local_ms) if isinstance(local_ms, dict) else {}
     data.setdefault("enable_fission", False)
@@ -285,8 +367,8 @@ async def clear_mail_domain_runtime_stats(token: str = Depends(verify_token)):
 async def clear_mail_domain_runtime_domain_counters(req: DomainRuntimeActionReq, token: str = Depends(verify_token)):
     item = mail_service.clear_mail_domain_runtime_domain_counters(req.domain)
     if not item:
-        return {"status": "error", "message": "未找到指定域名的运行时计数"}
-    return {"status": "success", "message": f"已清空 {item['domain']} 的计数", "item": item}
+        return {"status": "error", "message": "未找到指定域名的异常状态"}
+    return {"status": "success", "message": f"已清除 {item['domain']} 的异常", "item": item}
 
 
 @router.post("/api/config/mail_domain_runtime_stats/clear_cooldown")
@@ -312,6 +394,21 @@ async def save_config(new_config: dict, token: str = Depends(verify_token)):
             for item in new_config.get("mail_domain_failure_types", [])
             if str(item or "").strip()
         )) or ["discarded_email"]
+        def normalize_bool(value):
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                return value.strip().lower() in {"1", "true", "yes", "on"}
+            if isinstance(value, (int, float)):
+                return value != 0
+            return False
+        new_config["mail_domain_pinpoint_burst_mode"] = normalize_bool(new_config.get("mail_domain_pinpoint_burst_mode", False))
+        new_config["mail_domain_prefer_low_failure_mode"] = normalize_bool(new_config.get("mail_domain_prefer_low_failure_mode", False))
+        if new_config["mail_domain_pinpoint_burst_mode"] and new_config["mail_domain_prefer_low_failure_mode"]:
+            new_config["mail_domain_prefer_low_failure_mode"] = False
+        grouping_error = _normalize_mail_domain_grouping_payload(new_config)
+        if grouping_error:
+            return {"status": "error", "message": grouping_error}
         reload_all_configs(new_config_dict=new_config)
         mail_service.sync_mail_domain_runtime_state_with_config()
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -293,6 +293,18 @@ function normalizeBooleanLike(value, defaultValue = false) {
     return defaultValue;
 }
 
+function normalizeMailDomainCsv(value) {
+    const seen = new Set();
+    return String(value || '')
+        .split(',')
+        .map(part => String(part || '').trim().toLowerCase().replace(/^\.+|\.+$/g, ''))
+        .filter(part => {
+            if (!part || seen.has(part)) return false;
+            seen.add(part);
+            return true;
+        });
+}
+
 createApp({
     data() {
         return {
@@ -354,6 +366,9 @@ createApp({
             mailDomainRuntimeStatsError: '',
             mailDomainRuntimePanelCollapsed: normalizeBooleanLike(localStorage.getItem('mail_domain_runtime_panel_collapsed'), false),
             mailDomainRuntimeLastFetchAt: 0,
+            mailDomainRuntimePollIntervalMs: 2500,
+            mailDomainRuntimeFetchPromise: null,
+            mailDomainRuntimeFetchQueued: false,
             blacklistStr: "",
             warpListStr: "",
             rawProxyListStr: "",
@@ -590,6 +605,64 @@ createApp({
         },
         cooldownMailDomainCount() {
             return this.mailDomainRuntimeStats.filter(item => item && !item.is_available).length;
+        },
+        normalizedMailDomains() {
+            if (!this.config) return [];
+            return normalizeMailDomainCsv(this.config.mail_domains);
+        },
+        autoMailDomainGroupsPreview() {
+            if (!this.config || !this.config.enable_mail_domain_grouping || this.config.mail_domain_group_mode !== 'auto') {
+                return [];
+            }
+            const domains = this.normalizedMailDomains;
+            const groupCount = Math.min(10, Math.max(1, parseInt(this.config.mail_domain_group_count, 10) || 0));
+            if (domains.length === 0 || groupCount < 1 || groupCount > domains.length) {
+                return [];
+            }
+            const groups = Array.from({ length: groupCount }, () => []);
+            domains.forEach((domain, index) => {
+                groups[index % groupCount].push(domain);
+            });
+            return groups;
+        },
+        mailDomainGroupLabelMap() {
+            if (!this.config || !this.config.enable_mail_domain_grouping) {
+                return {};
+            }
+            const groups = this.config.mail_domain_group_mode === 'manual'
+                ? this.config.mail_domain_groups
+                    .map(group => normalizeMailDomainCsv(group))
+                    .filter(group => group.length > 0)
+                : this.autoMailDomainGroupsPreview;
+            return groups.reduce((map, group, index) => {
+                group.forEach(domain => {
+                    map[domain] = `[${index + 1}]`;
+                });
+                return map;
+            }, {});
+        },
+        sortedMailDomainRuntimeStats() {
+            if (!this.config || !this.config.enable_mail_domain_grouping) {
+                return this.mailDomainRuntimeStats;
+            }
+            const groups = this.config.mail_domain_group_mode === 'manual'
+                ? this.config.mail_domain_groups
+                    .map(group => normalizeMailDomainCsv(group))
+                    .filter(group => group.length > 0)
+                : this.autoMailDomainGroupsPreview;
+            const orderMap = groups.reduce((map, group, groupIndex) => {
+                group.forEach((domain, domainIndex) => {
+                    map[domain] = { groupIndex, domainIndex };
+                });
+                return map;
+            }, {});
+            return [...this.mailDomainRuntimeStats].sort((a, b) => {
+                const left = orderMap[a?.domain] || { groupIndex: Number.MAX_SAFE_INTEGER, domainIndex: Number.MAX_SAFE_INTEGER };
+                const right = orderMap[b?.domain] || { groupIndex: Number.MAX_SAFE_INTEGER, domainIndex: Number.MAX_SAFE_INTEGER };
+                if (left.groupIndex !== right.groupIndex) return left.groupIndex - right.groupIndex;
+                if (left.domainIndex !== right.domainIndex) return left.domainIndex - right.domainIndex;
+                return String(a?.domain || '').localeCompare(String(b?.domain || ''));
+            });
         }
     },
     methods: {
@@ -823,7 +896,7 @@ createApp({
         async initApp() {
             await this.fetchConfig();
             if (this.config?.enable_mail_domain_runtime_control) {
-                await this.fetchMailDomainRuntimeStats();
+                await this.fetchMailDomainRuntimeStats({ force: true });
             } else {
                 this.mailDomainRuntimeStats = [];
                 this.mailDomainRuntimeStatsError = '';
@@ -851,8 +924,28 @@ createApp({
             if(this.statsTimer) clearTimeout(this.statsTimer);
             this.pollStats();
         },
+        shouldPollMailDomainRuntimeStats() {
+            return !!(
+                this.currentTab === 'email' &&
+                this.isRunning &&
+                this.config?.enable_mail_domain_runtime_control &&
+                !this.mailDomainRuntimePanelCollapsed
+            );
+        },
+        queuePollStats() {
+            if (this._pollStatsInFlight) {
+                this._pollStatsQueued = true;
+                return;
+            }
+            this.pollStats();
+        },
         async pollStats() {
             if(!this.isLoggedIn) return;
+            if (this._pollStatsInFlight) {
+                this._pollStatsQueued = true;
+                return;
+            }
+            this._pollStatsInFlight = true;
             try {
                 const res = await this.authFetch('/api/stats');
                 const data = await res.json();
@@ -879,13 +972,10 @@ createApp({
                 }
 
                 if (
-                    this.currentTab === 'email' &&
-                    this.isRunning &&
-                    this.config?.enable_mail_domain_runtime_control &&
-                    !this.mailDomainRuntimePanelCollapsed &&
-                    Date.now() - this.mailDomainRuntimeLastFetchAt >= 1000
+                    this.shouldPollMailDomainRuntimeStats() &&
+                    Date.now() - this.mailDomainRuntimeLastFetchAt >= this.mailDomainRuntimePollIntervalMs
                 ) {
-                    this.fetchMailDomainRuntimeStats({ silent: true });
+                    await this.fetchMailDomainRuntimeStats({ silent: true });
                 }
 
                 if (this.currentTab === 'cluster') {
@@ -898,8 +988,14 @@ createApp({
             } catch(e) {
 
             } finally {
+                this._pollStatsInFlight = false;
+                if (this._pollStatsQueued) {
+                    this._pollStatsQueued = false;
+                    this.queuePollStats();
+                    return;
+                }
                 this.statsTimer = setTimeout(() => {
-                    this.pollStats();
+                    this.queuePollStats();
                 }, 1000);
             }
         },
@@ -1088,6 +1184,33 @@ createApp({
                 )];
                 if (this.config.enable_mail_domain_runtime_control === undefined) this.config.enable_mail_domain_runtime_control = false;
                 this.config.enable_mail_domain_runtime_control = normalizeBooleanLike(this.config.enable_mail_domain_runtime_control, false);
+                if (this.config.enable_mail_domain_grouping === undefined) this.config.enable_mail_domain_grouping = false;
+                this.config.enable_mail_domain_grouping = normalizeBooleanLike(this.config.enable_mail_domain_grouping, false);
+                if (this.config.mail_domain_group_count === undefined) this.config.mail_domain_group_count = 2;
+                this.config.mail_domain_group_count = Math.min(10, Math.max(1, parseInt(this.config.mail_domain_group_count, 10) || 2));
+                if (this.config.mail_domain_group_mode === undefined) this.config.mail_domain_group_mode = 'auto';
+                this.config.mail_domain_group_mode = ['auto', 'manual'].includes(String(this.config.mail_domain_group_mode || '').trim().toLowerCase())
+                    ? String(this.config.mail_domain_group_mode || '').trim().toLowerCase()
+                    : 'auto';
+                if (this.config.mail_domain_group_strategy === undefined) this.config.mail_domain_group_strategy = 'round_robin';
+                this.config.mail_domain_group_strategy = ['round_robin', 'exhaust_then_next'].includes(String(this.config.mail_domain_group_strategy || '').trim().toLowerCase())
+                    ? String(this.config.mail_domain_group_strategy || '').trim().toLowerCase()
+                    : 'round_robin';
+                if (!Array.isArray(this.config.mail_domain_groups)) this.config.mail_domain_groups = [];
+                this.config.mail_domain_groups = this.config.mail_domain_groups
+                    .slice(0, this.config.mail_domain_group_count)
+                    .map(item => normalizeMailDomainCsv(item).join(','));
+                while (this.config.mail_domain_groups.length < this.config.mail_domain_group_count) {
+                    this.config.mail_domain_groups.push('');
+                }
+                if (this.config.mail_domain_pinpoint_burst_mode === undefined) this.config.mail_domain_pinpoint_burst_mode = false;
+                this.config.mail_domain_pinpoint_burst_mode = normalizeBooleanLike(this.config.mail_domain_pinpoint_burst_mode, false);
+                if (this.config.mail_domain_prefer_low_failure_mode === undefined) this.config.mail_domain_prefer_low_failure_mode = false;
+                this.config.mail_domain_prefer_low_failure_mode = normalizeBooleanLike(this.config.mail_domain_prefer_low_failure_mode, false);
+                if (this.config.mail_domain_pinpoint_burst_mode && this.config.mail_domain_prefer_low_failure_mode) {
+                    this.config.mail_domain_prefer_low_failure_mode = false;
+                }
+                this.applyMailDomainModeConstraints();
                 if (!Array.isArray(this.config.mail_domain_failure_types)) this.config.mail_domain_failure_types = ['discarded_email'];
                 this.config.mail_domain_failure_types = [...new Set(
                     this.config.mail_domain_failure_types
@@ -1099,37 +1222,150 @@ createApp({
                 if (this.config.mail_domain_fail_cooldown_sec === undefined) this.config.mail_domain_fail_cooldown_sec = 600;
             } catch (e) {}
         },
+        applyMailDomainModeExclusion(changedMode = '') {
+            this.applyMailDomainModeConstraints(changedMode);
+        },
+        applyMailDomainModeConstraints(changedMode = '') {
+            if (!this.config) return;
+            this.config.enable_mail_domain_grouping = normalizeBooleanLike(this.config.enable_mail_domain_grouping, false);
+            this.config.mail_domain_pinpoint_burst_mode = normalizeBooleanLike(this.config.mail_domain_pinpoint_burst_mode, false);
+            this.config.mail_domain_prefer_low_failure_mode = normalizeBooleanLike(this.config.mail_domain_prefer_low_failure_mode, false);
+            this.config.mail_domain_group_count = Math.min(10, Math.max(1, parseInt(this.config.mail_domain_group_count, 10) || 2));
+            this.config.mail_domain_group_mode = ['auto', 'manual'].includes(String(this.config.mail_domain_group_mode || '').trim().toLowerCase())
+                ? String(this.config.mail_domain_group_mode || '').trim().toLowerCase()
+                : 'auto';
+            this.config.mail_domain_group_strategy = ['round_robin', 'exhaust_then_next'].includes(String(this.config.mail_domain_group_strategy || '').trim().toLowerCase())
+                ? String(this.config.mail_domain_group_strategy || '').trim().toLowerCase()
+                : 'round_robin';
+            if (!Array.isArray(this.config.mail_domain_groups)) {
+                this.config.mail_domain_groups = [];
+            }
+            this.config.mail_domain_groups = this.config.mail_domain_groups
+                .slice(0, this.config.mail_domain_group_count)
+                .map(item => normalizeMailDomainCsv(item).join(','));
+            while (this.config.mail_domain_groups.length < this.config.mail_domain_group_count) {
+                this.config.mail_domain_groups.push('');
+            }
+            if (changedMode === 'grouping' && this.config.enable_mail_domain_grouping) {
+                this.config.mail_domain_pinpoint_burst_mode = false;
+            }
+            if (changedMode === 'pinpoint' && this.config.mail_domain_pinpoint_burst_mode) {
+                this.config.enable_mail_domain_grouping = false;
+            }
+            if (this.config.enable_mail_domain_grouping && this.config.mail_domain_pinpoint_burst_mode) {
+                if (changedMode === 'pinpoint') {
+                    this.config.enable_mail_domain_grouping = false;
+                } else {
+                    this.config.mail_domain_pinpoint_burst_mode = false;
+                }
+            }
+            if (this.config.mail_domain_pinpoint_burst_mode && this.config.mail_domain_prefer_low_failure_mode) {
+                if (changedMode === 'pinpoint') {
+                    this.config.mail_domain_prefer_low_failure_mode = false;
+                } else if (changedMode === 'low_failure') {
+                    this.config.mail_domain_pinpoint_burst_mode = false;
+                } else {
+                    this.config.mail_domain_prefer_low_failure_mode = false;
+                }
+            }
+        },
+        validateMailDomainGrouping() {
+            if (!this.config) return '';
+            this.applyMailDomainModeConstraints();
+            if (!this.config.enable_mail_domain_grouping) {
+                return '';
+            }
+            const masterDomains = normalizeMailDomainCsv(this.config.mail_domains);
+            if (masterDomains.length === 0) {
+                return '启用域名分组前请先填写 mail_domains';
+            }
+            const groupCount = Math.min(10, Math.max(1, parseInt(this.config.mail_domain_group_count, 10) || 0));
+            if (groupCount < 1 || groupCount > 10) {
+                return '分组数量必须在 1 到 10 之间';
+            }
+            if (groupCount > masterDomains.length) {
+                return '分组数量不能大于有效主域名数量';
+            }
+            if (this.config.mail_domain_group_mode !== 'manual') {
+                return '';
+            }
+            const masterSet = new Set(masterDomains);
+            const assigned = new Set();
+            for (let index = 0; index < groupCount; index += 1) {
+                const domains = normalizeMailDomainCsv(this.config.mail_domain_groups[index] || '');
+                if (domains.length === 0) {
+                    return `第 ${index + 1} 组至少需要填写一个域名`;
+                }
+                for (const domain of domains) {
+                    if (!masterSet.has(domain)) {
+                        return `第 ${index + 1} 组存在未配置在 mail_domains 中的域名: ${domain}`;
+                    }
+                    if (assigned.has(domain)) {
+                        return `域名 ${domain} 不能重复出现在多个分组中`;
+                    }
+                    assigned.add(domain);
+                }
+            }
+            const missing = masterDomains.filter(domain => !assigned.has(domain));
+            if (missing.length > 0) {
+                return `手动分组未覆盖所有主域名，缺少: ${missing.join(', ')}`;
+            }
+            return '';
+        },
+        normalizeMailDomainGroupInput(index) {
+            if (!this.config || !Array.isArray(this.config.mail_domain_groups)) return;
+            this.config.mail_domain_groups[index] = normalizeMailDomainCsv(this.config.mail_domain_groups[index]).join(',');
+        },
         async fetchMailDomainRuntimeStats(options = {}) {
-            const { silent = false } = options;
+            const { silent = false, force = false } = options;
             if (!this.config?.enable_mail_domain_runtime_control) {
                 this.mailDomainRuntimeStats = [];
                 this.mailDomainRuntimeStatsError = '';
                 this.mailDomainRuntimeLastFetchAt = 0;
+                this.mailDomainRuntimeFetchPromise = null;
+                this.mailDomainRuntimeFetchQueued = false;
                 return;
             }
-            try {
-                const res = await this.authFetch('/api/config/mail_domain_runtime_stats');
-                const data = await res.json();
-                if (data.status === 'success' && Array.isArray(data.items)) {
-                    this.mailDomainRuntimeStats = data.items;
-                    this.mailDomainRuntimeStatsError = '';
-                    this.mailDomainRuntimeLastFetchAt = Date.now();
-                } else {
-                    this.mailDomainRuntimeStatsError = data.message || '域名运行时状态获取失败';
+            if (!force && this.mailDomainRuntimeFetchPromise) {
+                this.mailDomainRuntimeFetchQueued = true;
+                return this.mailDomainRuntimeFetchPromise;
+            }
+            const request = (async () => {
+                try {
+                    const res = await this.authFetch('/api/config/mail_domain_runtime_stats');
+                    const data = await res.json();
+                    if (data.status === 'success' && Array.isArray(data.items)) {
+                        this.mailDomainRuntimeStats = data.items;
+                        this.mailDomainRuntimeStatsError = '';
+                        this.mailDomainRuntimeLastFetchAt = Date.now();
+                    } else {
+                        this.mailDomainRuntimeStatsError = data.message || '域名运行时状态获取失败';
+                        if (!silent) {
+                            this.showToast(this.mailDomainRuntimeStatsError, 'error');
+                        }
+                    }
+                } catch (e) {
+                    this.mailDomainRuntimeStatsError = '域名运行时状态获取失败，请检查后端接口或网络连接';
                     if (!silent) {
                         this.showToast(this.mailDomainRuntimeStatsError, 'error');
                     }
+                } finally {
+                    this.mailDomainRuntimeFetchPromise = null;
+                    if (this.mailDomainRuntimeFetchQueued) {
+                        this.mailDomainRuntimeFetchQueued = false;
+                        this.fetchMailDomainRuntimeStats({ silent: true, force: true });
+                    }
                 }
-            } catch (e) {
-                this.mailDomainRuntimeStatsError = '域名运行时状态获取失败，请检查后端接口或网络连接';
-                if (!silent) {
-                    this.showToast(this.mailDomainRuntimeStatsError, 'error');
-                }
-            }
+            })();
+            this.mailDomainRuntimeFetchPromise = request;
+            return request;
         },
         toggleMailDomainRuntimePanel() {
             this.mailDomainRuntimePanelCollapsed = !this.mailDomainRuntimePanelCollapsed;
             localStorage.setItem('mail_domain_runtime_panel_collapsed', this.mailDomainRuntimePanelCollapsed ? 'true' : 'false');
+            if (!this.mailDomainRuntimePanelCollapsed && this.config?.enable_mail_domain_runtime_control) {
+                this.fetchMailDomainRuntimeStats({ silent: true, force: true });
+            }
         },
         isMailDomainRuntimePristine(item) {
             if (!item || typeof item !== 'object') return false;
@@ -1161,8 +1397,8 @@ createApp({
                 if (data.status === 'success') {
                     this.mailDomainRuntimeStatsError = '';
                     this.showToast(data.message || '已清除全部域名冷却', 'success');
-                    await this.fetchMailDomainRuntimeStats({ silent: true });
-                    this.pollStats();
+                    await this.fetchMailDomainRuntimeStats({ silent: true, force: true });
+                    this.queuePollStats();
                 } else {
                     this.showToast(data.message || '清除全部域名冷却失败', 'error');
                 }
@@ -1178,14 +1414,14 @@ createApp({
                 });
                 const data = await res.json();
                 if (data.status === 'success') {
-                    this.showToast(data.message || '已清空域名计数', 'success');
-                    await this.fetchMailDomainRuntimeStats({ silent: true });
-                    this.pollStats();
+                    this.showToast(data.message || '已清除域名异常', 'success');
+                    await this.fetchMailDomainRuntimeStats({ silent: true, force: true });
+                    this.queuePollStats();
                 } else {
-                    this.showToast(data.message || '清空域名计数失败', 'error');
+                    this.showToast(data.message || '清除域名异常失败', 'error');
                 }
             } catch (e) {
-                this.showToast('清空域名计数失败，请检查网络连接', 'error');
+                this.showToast('清除域名异常失败，请检查网络连接', 'error');
             }
         },
         async clearMailDomainRuntimeRowCooldown(domain) {
@@ -1197,8 +1433,8 @@ createApp({
                 const data = await res.json();
                 if (data.status === 'success') {
                     this.showToast(data.message || '已清除域名冷却', 'success');
-                    await this.fetchMailDomainRuntimeStats({ silent: true });
-                    this.pollStats();
+                    await this.fetchMailDomainRuntimeStats({ silent: true, force: true });
+                    this.queuePollStats();
                 } else {
                     this.showToast(data.message || '清除域名冷却失败', 'error');
                 }
@@ -1235,6 +1471,17 @@ createApp({
                     this.config.local_microsoft.suffix_len_max = maxLen;
                 }
                 this.config.enable_mail_domain_runtime_control = normalizeBooleanLike(this.config.enable_mail_domain_runtime_control, false);
+                this.config.enable_mail_domain_grouping = normalizeBooleanLike(this.config.enable_mail_domain_grouping, false);
+                if (this.config.mail_domain_pinpoint_burst_mode === undefined) this.config.mail_domain_pinpoint_burst_mode = false;
+                this.config.mail_domain_pinpoint_burst_mode = normalizeBooleanLike(this.config.mail_domain_pinpoint_burst_mode, false);
+                if (this.config.mail_domain_prefer_low_failure_mode === undefined) this.config.mail_domain_prefer_low_failure_mode = false;
+                this.config.mail_domain_prefer_low_failure_mode = normalizeBooleanLike(this.config.mail_domain_prefer_low_failure_mode, false);
+                this.applyMailDomainModeConstraints();
+                const mailDomainGroupingError = this.validateMailDomainGrouping();
+                if (mailDomainGroupingError) {
+                    this.showToast(mailDomainGroupingError, 'warning');
+                    return;
+                }
                 if (!Array.isArray(this.config.mail_domain_failure_types)) {
                     this.config.mail_domain_failure_types = ['discarded_email'];
                 }
@@ -1274,8 +1521,8 @@ createApp({
                 if(data.status === 'success') {
                     this.showToast(data.message, "success");
                     await this.fetchConfig();
-                    await this.fetchMailDomainRuntimeStats();
-                    this.pollStats();
+                    await this.fetchMailDomainRuntimeStats({ force: true });
+                    this.queuePollStats();
                 } else { this.showToast("保存失败：" + data.message, "error"); }
             } catch (e) { this.showToast("保存失败网络异常", "error"); }
         },
@@ -1347,14 +1594,14 @@ createApp({
             this.currentTab = tabId;
             window.location.hash = tabId;
 			if (tabId === 'console') {
-				this.pollStats();
+				this.queuePollStats();
 			}
             if (tabId === 'accounts') {
                 this.fetchAccounts();
             }
 			if (tabId === 'email') {
 				this.fetchConfig();
-                    this.fetchMailDomainRuntimeStats();
+                    this.fetchMailDomainRuntimeStats({ force: true });
 			}
 			if (tabId === 'cloud') {
 			    this.fetchCloudAccounts();
@@ -1603,8 +1850,8 @@ createApp({
                 if (data.status === 'success') {
                     this.isRunning = true;
                     this.currentTab = 'console';
-                    this.pollStats();
-                    await this.fetchMailDomainRuntimeStats();
+                    this.queuePollStats();
+                    await this.fetchMailDomainRuntimeStats({ force: true });
                     this.showToast(`启动成功`, "success");
                 } else { this.showToast(data.message, "error"); }
             } catch (e) { this.showToast("启动请求发送失败", "error"); }
@@ -1615,7 +1862,7 @@ createApp({
                 const data = await res.json();
                 this.showToast("任务已停止", "info");
                 this.isRunning = false;
-                await this.fetchMailDomainRuntimeStats();
+                await this.fetchMailDomainRuntimeStats({ force: true });
                 const now = new Date();
             const timeStr = formatMainlandTime(now); // 获取如 14:30:05 格式
                 this.logs.push({
@@ -1632,7 +1879,7 @@ createApp({
                         container.scrollTop = container.scrollHeight;
                     }
                 });
-                this.pollStats();
+                this.queuePollStats();
             } catch (e) {
                 this.showToast("停止请求发送失败", "error");
             }
@@ -2297,7 +2544,7 @@ createApp({
 
                 if(data.code === 200) {
                     this.showToast(data.message, 'success');
-                    this.pollStats();
+                    this.queuePollStats();
                 } else {
                     this.showToast(data.message || '启动测活失败', 'error');
                 }

--- a/utils/auth_pipeline/register.py
+++ b/utils/auth_pipeline/register.py
@@ -19,7 +19,13 @@ from .oauth import generate_oauth_url, submit_callback_url
 from .user_utils import _generate_password
 
 
-def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
+def run(
+    proxy: Optional[str],
+    run_ctx: dict = None,
+    assigned_domain: Optional[str] = None,
+    batch_id: Optional[int] = None,
+    worker_index: Optional[int] = None,
+) -> tuple:
     processed_mails: set = set()
     proxy = cfg.format_docker_url(proxy)
     if proxy and proxy.startswith("socks5://"):
@@ -57,7 +63,12 @@ def run(proxy: Optional[str], run_ctx: dict = None) -> tuple:
         del s_reg
         s_reg = None
 
-        email, email_jwt = get_email_and_token(proxies)
+        email, email_jwt = get_email_and_token(
+            proxies,
+            assigned_domain=assigned_domain,
+            batch_id=batch_id,
+            worker_index=worker_index,
+        )
         if not email:
             return None, None
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -188,6 +188,13 @@ EMAIL_API_MODE: str = ""
 MAIL_DOMAINS: str = ""
 DISABLED_MAIL_DOMAINS: list[str] = []
 ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL: bool = False
+ENABLE_MAIL_DOMAIN_GROUPING: bool = False
+MAIL_DOMAIN_GROUP_COUNT: int = 2
+MAIL_DOMAIN_GROUP_MODE: str = "auto"
+MAIL_DOMAIN_GROUP_STRATEGY: str = "round_robin"
+MAIL_DOMAIN_GROUPS: list[str] = []
+MAIL_DOMAIN_PINPOINT_BURST_MODE: bool = False
+MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE: bool = False
 MAIL_DOMAIN_FAILURE_TYPES: list[str] = ["discarded_email"]
 MAIL_DOMAIN_FAIL_THRESHOLD: int = 3
 MAIL_DOMAIN_FAIL_COOLDOWN_SEC: int = 600
@@ -405,6 +412,10 @@ def reload_all_configs(new_config_dict=None):
     global EMAIL_API_MODE, MAIL_DOMAINS, GPTMAIL_BASE, ADMIN_AUTH
     global DISABLED_MAIL_DOMAINS
     global ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL
+    global ENABLE_MAIL_DOMAIN_GROUPING, MAIL_DOMAIN_GROUP_COUNT, MAIL_DOMAIN_GROUP_MODE
+    global MAIL_DOMAIN_GROUP_STRATEGY, MAIL_DOMAIN_GROUPS
+    global MAIL_DOMAIN_PINPOINT_BURST_MODE
+    global MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE
     global MAIL_DOMAIN_FAILURE_TYPES, MAIL_DOMAIN_FAIL_THRESHOLD, MAIL_DOMAIN_FAIL_COOLDOWN_SEC
     global ENABLE_SUB_DOMAINS, SUB_DOMAIN_COUNT
     global IMAP_SERVER, IMAP_PORT, IMAP_USER, IMAP_PASS
@@ -548,6 +559,16 @@ def reload_all_configs(new_config_dict=None):
                 domains.append(text)
         return domains
 
+    def normalize_mail_domain_string(value):
+        seen = set()
+        domains = []
+        for part in str(value or "").split(","):
+            text = str(part or "").strip().lower().strip(".")
+            if text and text not in seen:
+                seen.add(text)
+                domains.append(text)
+        return domains
+
     def safe_bool(value, default=False):
         if isinstance(value, bool):
             return value
@@ -580,6 +601,30 @@ def reload_all_configs(new_config_dict=None):
     MAIL_DOMAINS = _c.get("mail_domains", "")
     DISABLED_MAIL_DOMAINS = normalize_domain_list(_c.get("disabled_mail_domains", []))
     ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL = safe_bool(_c.get("enable_mail_domain_runtime_control", False), default=False)
+    ENABLE_MAIL_DOMAIN_GROUPING = safe_bool(_c.get("enable_mail_domain_grouping", False), default=False)
+    MAIL_DOMAIN_GROUP_COUNT = safe_int(_c.get("mail_domain_group_count", 2), default=2, minimum=1)
+    MAIL_DOMAIN_GROUP_COUNT = min(10, MAIL_DOMAIN_GROUP_COUNT)
+    MAIL_DOMAIN_GROUP_MODE = str(_c.get("mail_domain_group_mode", "auto") or "auto").strip().lower()
+    if MAIL_DOMAIN_GROUP_MODE not in {"auto", "manual"}:
+        MAIL_DOMAIN_GROUP_MODE = "auto"
+    MAIL_DOMAIN_GROUP_STRATEGY = str(_c.get("mail_domain_group_strategy", "round_robin") or "round_robin").strip().lower()
+    if MAIL_DOMAIN_GROUP_STRATEGY not in {"round_robin", "exhaust_then_next"}:
+        MAIL_DOMAIN_GROUP_STRATEGY = "round_robin"
+    raw_mail_domain_groups = _c.get("mail_domain_groups", [])
+    if not isinstance(raw_mail_domain_groups, list):
+        raw_mail_domain_groups = []
+    MAIL_DOMAIN_GROUPS = [
+        ",".join(normalize_mail_domain_string(item))
+        for item in raw_mail_domain_groups[:MAIL_DOMAIN_GROUP_COUNT]
+    ]
+    while len(MAIL_DOMAIN_GROUPS) < MAIL_DOMAIN_GROUP_COUNT:
+        MAIL_DOMAIN_GROUPS.append("")
+    MAIL_DOMAIN_PINPOINT_BURST_MODE = safe_bool(_c.get("mail_domain_pinpoint_burst_mode", False), default=False)
+    MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE = safe_bool(_c.get("mail_domain_prefer_low_failure_mode", False), default=False)
+    if ENABLE_MAIL_DOMAIN_GROUPING:
+        MAIL_DOMAIN_PINPOINT_BURST_MODE = False
+    if MAIL_DOMAIN_PINPOINT_BURST_MODE and MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE:
+        MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE = False
     MAIL_DOMAIN_FAILURE_TYPES = [
         str(item or "").strip().lower()
         for item in (_c.get("mail_domain_failure_types", ["discarded_email"]) or ["discarded_email"])

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -711,17 +711,23 @@ def handle_registration_result(result: Any, cpa_upload: bool = False, run_ctx: d
         send_tg_msg_sync(success_text)
     return ret_status
 
-def run_and_refresh(proxy, args, cpa_upload=False, skip_switch=False):
+def run_and_refresh(proxy, args, cpa_upload=False, skip_switch=False, assigned_domain=None, batch_id=None, worker_index=None):
     proxy = format_docker_url(proxy)
     """切节点 → 注册 → 处理结果。"""
     if not skip_switch:
         if not smart_switch_node(proxy):
             print(f"[{ts()}] [WARNING] {proxy} 节点切换失败，将使用当前 IP 继续尝试...")
-    
+
     result = None
     run_ctx = {}
     try:
-        result = run(proxy, run_ctx=run_ctx)
+        result = run(
+            proxy,
+            run_ctx=run_ctx,
+            assigned_domain=assigned_domain,
+            batch_id=batch_id,
+            worker_index=worker_index,
+        )
     except Exception as e:
         print(f"[{ts()}] [ERROR] 注册线程发生未捕获异常{e}")
         import traceback
@@ -1037,12 +1043,31 @@ def normal_main_loop(args, stop_event: threading.Event, executor=None):
                 )
                 print(f"[{ts()}] [INFO] 启用多线程并发 ({current_batch} 条通道)")
 
-                def _worker():
+                should_preallocate_domains = (
+                    current_batch > 1
+                    and getattr(cfg, 'ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL', False)
+                )
+                preallocated_domains = []
+                batch_id = None
+                if should_preallocate_domains:
+                    batch_id = int(time.time() * 1000)
+                    domain_pool = mail_service.get_configured_main_domains_snapshot()
+                    preallocated_domains = mail_service.preallocate_main_domains_for_batch(domain_pool, current_batch)
+
+                def _worker(worker_index=0, assigned_domain=None):
                     if stop_event.is_set(): return "stopped"
                     if cfg.is_raw_proxy_pool_enabled():
                         borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
                         try:
-                            return run_and_refresh(p, args, False, skip_switch=True)
+                            return run_and_refresh(
+                                p,
+                                args,
+                                False,
+                                skip_switch=True,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             if cfg.should_return_pooled_proxy(borrowed_generation):
                                 cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
@@ -1051,20 +1076,42 @@ def normal_main_loop(args, stop_event: threading.Event, executor=None):
                         p = cfg.PROXY_QUEUE.get()
                         proxy_url = p[-1] if isinstance(p, tuple) else p
                         try:
-                            return run_and_refresh(proxy_url, args, False, skip_switch=False)
+                            return run_and_refresh(
+                                proxy_url,
+                                args,
+                                False,
+                                skip_switch=False,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             cfg.PROXY_QUEUE.put(p)
                             cfg.PROXY_QUEUE.task_done()
-                    return run_and_refresh(args.proxy, args, False, skip_switch=True)
+                    return run_and_refresh(
+                        args.proxy,
+                        args,
+                        False,
+                        skip_switch=True,
+                        assigned_domain=assigned_domain,
+                        batch_id=batch_id,
+                        worker_index=worker_index,
+                    )
 
                 if executor is not None:
-                    futures = [executor.submit(_worker) for _ in range(current_batch)]
+                    futures = [
+                        executor.submit(_worker, idx, preallocated_domains[idx] if idx < len(preallocated_domains) else None)
+                        for idx in range(current_batch)
+                    ]
                     for f in futures:
                         if f.result() == "success":
                             success_count += 1
                 else:
                     with ThreadPoolExecutor(max_workers=current_batch) as ex:
-                        futures = [ex.submit(_worker) for _ in range(current_batch)]
+                        futures = [
+                            ex.submit(_worker, idx, preallocated_domains[idx] if idx < len(preallocated_domains) else None)
+                            for idx in range(current_batch)
+                        ]
                         for f in futures:
                             if f.result() == "success":
                                 success_count += 1
@@ -1255,12 +1302,20 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event, executor=None):
                 print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.MIN_ACCOUNTS_THRESHOLD})，启动补货...")
                 await asyncio.sleep(1)
 
-                def _cpa_worker():
+                def _cpa_worker(worker_index=0, assigned_domain=None, batch_id=None):
                     if async_stop_event.is_set(): return "stopped"
                     if cfg.is_raw_proxy_pool_enabled():
                         borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
                         try:
-                            return run_and_refresh(p, args, cpa_upload=True, skip_switch=True)
+                            return run_and_refresh(
+                                p,
+                                args,
+                                cpa_upload=True,
+                                skip_switch=True,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             if cfg.should_return_pooled_proxy(borrowed_generation):
                                 cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
@@ -1269,35 +1324,74 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event, executor=None):
                         p = cfg.PROXY_QUEUE.get()
                         proxy_url = p[-1] if isinstance(p, tuple) else p
                         try:
-                            return run_and_refresh(proxy_url, args, cpa_upload=True, skip_switch=False)
+                            return run_and_refresh(
+                                proxy_url,
+                                args,
+                                cpa_upload=True,
+                                skip_switch=False,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             cfg.PROXY_QUEUE.put(p)
                             cfg.PROXY_QUEUE.task_done()
-                    return run_and_refresh(args.proxy, args, cpa_upload=True, skip_switch=True)
+                    return run_and_refresh(
+                        args.proxy,
+                        args,
+                        cpa_upload=True,
+                        skip_switch=True,
+                        assigned_domain=assigned_domain,
+                        batch_id=batch_id,
+                        worker_index=worker_index,
+                    )
 
                 while success_in_this_cycle < need_to_reg and not async_stop_event.is_set() and not cfg.POOL_EXHAUSTED:
                     remaining  = need_to_reg - success_in_this_cycle
                     batch_size = min(cfg.REG_THREADS, remaining)
+                    preallocated_domains = []
+                    batch_id = None
 
                     if cfg._clash_enable and not cfg._clash_pool_mode:
                         print(f"[{ts()}] [INFO] [CPA补货] 切换全局节点...")
                         if not smart_switch_node(args.proxy):
                             print(f"[{ts()}] [WARNING] [CPA补货] 全局节点切换失败，使用当前 IP 继续...")
 
+                    if (
+                        cfg.ENABLE_MULTI_THREAD_REG
+                        and batch_size > 1
+                        and getattr(cfg, 'ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL', False)
+                    ):
+                        batch_id = int(time.time() * 1000)
+                        domain_pool = mail_service.get_configured_main_domains_snapshot()
+                        preallocated_domains = mail_service.preallocate_main_domains_for_batch(domain_pool, batch_size)
+
                     if cfg.ENABLE_MULTI_THREAD_REG:
                         print(f"[{ts()}] [INFO] 多线程补货: {success_in_this_cycle}/{need_to_reg} "
                               f"({batch_size} 线程)")
                         if executor is not None:
                             reg_futures = [
-                                loop.run_in_executor(executor, _cpa_worker)
-                                for _ in range(batch_size)
+                                loop.run_in_executor(
+                                    executor,
+                                    _cpa_worker,
+                                    idx,
+                                    preallocated_domains[idx] if idx < len(preallocated_domains) else None,
+                                    batch_id,
+                                )
+                                for idx in range(batch_size)
                             ]
                             reg_results = await asyncio.gather(*reg_futures)
                         else:
                             with ThreadPoolExecutor(max_workers=batch_size) as ex:
                                 reg_futures = [
-                                    loop.run_in_executor(ex, _cpa_worker)
-                                    for _ in range(batch_size)
+                                    loop.run_in_executor(
+                                        ex,
+                                        _cpa_worker,
+                                        idx,
+                                        preallocated_domains[idx] if idx < len(preallocated_domains) else None,
+                                        batch_id,
+                                    )
+                                    for idx in range(batch_size)
                                 ]
                                 reg_results = await asyncio.gather(*reg_futures)
                         for status in reg_results:
@@ -1435,13 +1529,19 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
                 print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.SUB2API_MIN_THRESHOLD})，启动补货...")
                 await asyncio.sleep(1)
 
-                def _sub2api_run_wrapper(p, skip_switch):
+                def _sub2api_run_wrapper(p, skip_switch, assigned_domain=None, batch_id=None, worker_index=None):
                     p = format_docker_url(p)
                     if not skip_switch:
                         if not smart_switch_node(p):
                             print(f"[{ts()}] [WARNING] [Sub2API补货] 全局节点切换失败...")
                     run_ctx = {}
-                    result = run(p, run_ctx=run_ctx)
+                    result = run(
+                        p,
+                        run_ctx=run_ctx,
+                        assigned_domain=assigned_domain,
+                        batch_id=batch_id,
+                        worker_index=worker_index,
+                    )
                     status = handle_registration_result(result, cpa_upload=False, run_ctx=run_ctx)
 
                     if status == "success":
@@ -1452,12 +1552,18 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
                             else: print(f"[{ts()}] [ERROR] Sub2API 补货入库失败: {msg}")
                     return status
 
-                def _sub2api_worker():
+                def _sub2api_worker(worker_index=0, assigned_domain=None, batch_id=None):
                     if async_stop_event.is_set(): return "stopped"
                     if cfg.is_raw_proxy_pool_enabled():
                         borrowed_generation, p = cfg.unpack_proxy_queue_item(cfg.PROXY_QUEUE.get())
                         try:
-                            return _sub2api_run_wrapper(p, True)
+                            return _sub2api_run_wrapper(
+                                p,
+                                True,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             if cfg.should_return_pooled_proxy(borrowed_generation):
                                 cfg.PROXY_QUEUE.put(cfg.make_proxy_queue_item(p, borrowed_generation))
@@ -1466,35 +1572,70 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
                         p = cfg.PROXY_QUEUE.get()
                         proxy_url = p[-1] if isinstance(p, tuple) else p
                         try:
-                            return _sub2api_run_wrapper(proxy_url, False)
+                            return _sub2api_run_wrapper(
+                                proxy_url,
+                                False,
+                                assigned_domain=assigned_domain,
+                                batch_id=batch_id,
+                                worker_index=worker_index,
+                            )
                         finally:
                             cfg.PROXY_QUEUE.put(p)
                             cfg.PROXY_QUEUE.task_done()
-                    return _sub2api_run_wrapper(args.proxy, True)
+                    return _sub2api_run_wrapper(
+                        args.proxy,
+                        True,
+                        assigned_domain=assigned_domain,
+                        batch_id=batch_id,
+                        worker_index=worker_index,
+                    )
 
                 while success_in_this_cycle < need_to_reg and not async_stop_event.is_set() and not cfg.POOL_EXHAUSTED:
                     remaining  = need_to_reg - success_in_this_cycle
                     batch_size = min(cfg.REG_THREADS, remaining)
+                    preallocated_domains = []
+                    batch_id = None
 
                     if cfg._clash_enable and not cfg._clash_pool_mode:
                         print(f"[{ts()}] [INFO] [Sub2API补货] 切换全局节点...")
                         if not smart_switch_node(args.proxy):
                             print(f"[{ts()}] [WARNING] [Sub2API补货] 全局节点切换失败，使用当前 IP 继续...")
 
+                    if (
+                        cfg.ENABLE_MULTI_THREAD_REG
+                        and batch_size > 1
+                        and getattr(cfg, 'ENABLE_MAIL_DOMAIN_RUNTIME_CONTROL', False)
+                    ):
+                        batch_id = int(time.time() * 1000)
+                        domain_pool = mail_service.get_configured_main_domains_snapshot()
+                        preallocated_domains = mail_service.preallocate_main_domains_for_batch(domain_pool, batch_size)
+
                     if cfg.ENABLE_MULTI_THREAD_REG:
                         print(f"[{ts()}] [INFO] 多线程补货: {success_in_this_cycle}/{need_to_reg} "
                               f"({batch_size} 线程)")
                         if executor is not None:
                             reg_futures = [
-                                loop.run_in_executor(executor, _sub2api_worker)
-                                for _ in range(batch_size)
+                                loop.run_in_executor(
+                                    executor,
+                                    _sub2api_worker,
+                                    idx,
+                                    preallocated_domains[idx] if idx < len(preallocated_domains) else None,
+                                    batch_id,
+                                )
+                                for idx in range(batch_size)
                             ]
                             reg_results = await asyncio.gather(*reg_futures)
                         else:
                             with ThreadPoolExecutor(max_workers=batch_size) as ex:
                                 reg_futures = [
-                                    loop.run_in_executor(ex, _sub2api_worker)
-                                    for _ in range(batch_size)
+                                    loop.run_in_executor(
+                                        ex,
+                                        _sub2api_worker,
+                                        idx,
+                                        preallocated_domains[idx] if idx < len(preallocated_domains) else None,
+                                        batch_id,
+                                    )
+                                    for idx in range(batch_size)
                                 ]
                                 reg_results = await asyncio.gather(*reg_futures)
 

--- a/utils/email_providers/mail_service.py
+++ b/utils/email_providers/mail_service.py
@@ -52,10 +52,21 @@ _CM_TOKEN_CACHE: Optional[str] = None
 _DOMAIN_RUNTIME_LOCK = threading.Lock()
 _DOMAIN_RUNTIME_STATE = {}
 _MAIL_DOMAIN_FAILURE_TYPES = {"discarded_email", "cloudflare_temp_email_network", "capacity_exceeded"}
+_MAIL_DOMAIN_CONFIG_CACHE = {
+    "key": None,
+    "main_domains": (),
+    "main_domain_set": frozenset(),
+    "disabled_main_domains": frozenset(),
+    "selected_failure_types": frozenset(),
+    "effective_groups": (),
+}
 _DOMAIN_RUNTIME_SESSION = {
     "counting_enabled": False,
     "last_started_at": 0.0,
     "last_stopped_at": 0.0,
+    "tie_break_cursor": 0,
+    "group_cursor": 0,
+    "group_sticky_cursor": 0,
 }
 
 _thread_data = threading.local()
@@ -111,15 +122,162 @@ def pop_last_domain_failure_event() -> dict:
     return dict(event) if isinstance(event, dict) else {}
 
 
-def _get_configured_main_domains() -> list[str]:
+def _parse_mail_domain_items(raw_value: Any) -> list[str]:
     seen = set()
     domains = []
-    for part in str(getattr(cfg, 'MAIL_DOMAINS', '') or '').split(','):
+    for part in str(raw_value or '').split(','):
         root = str(part or '').strip().lower().strip('.')
         if root and root not in seen:
             seen.add(root)
             domains.append(root)
     return domains
+
+
+def _get_mail_domain_config_cache() -> dict[str, Any]:
+    mail_domains_raw = str(getattr(cfg, 'MAIL_DOMAINS', '') or '')
+    disabled_raw = tuple(
+        str(item or '').strip().lower().strip('.')
+        for item in (getattr(cfg, 'DISABLED_MAIL_DOMAINS', []) or [])
+    )
+    selected_failure_raw = tuple(
+        str(item or '').strip().lower()
+        for item in (getattr(cfg, 'MAIL_DOMAIN_FAILURE_TYPES', []) or [])
+    )
+    grouping_enabled = bool(
+        is_mail_domain_runtime_control_enabled()
+        and getattr(cfg, 'ENABLE_MAIL_DOMAIN_GROUPING', False)
+    )
+    group_count = max(1, min(10, int(getattr(cfg, 'MAIL_DOMAIN_GROUP_COUNT', 2) or 2)))
+    group_mode = str(getattr(cfg, 'MAIL_DOMAIN_GROUP_MODE', 'auto') or 'auto').strip().lower()
+    group_strategy = str(getattr(cfg, 'MAIL_DOMAIN_GROUP_STRATEGY', 'round_robin') or 'round_robin').strip().lower()
+    raw_groups = tuple(str(item or '') for item in (getattr(cfg, 'MAIL_DOMAIN_GROUPS', []) or []))
+
+    cache_key = (
+        mail_domains_raw,
+        disabled_raw,
+        selected_failure_raw,
+        grouping_enabled,
+        group_count,
+        group_mode,
+        group_strategy,
+        raw_groups,
+    )
+    cached_key = _MAIL_DOMAIN_CONFIG_CACHE.get("key")
+    if cached_key == cache_key:
+        return _MAIL_DOMAIN_CONFIG_CACHE
+
+    main_domains = tuple(_parse_mail_domain_items(mail_domains_raw))
+    main_domain_set = frozenset(main_domains)
+
+    disabled_main_domains = frozenset(
+        domain
+        for domain in disabled_raw
+        if domain in main_domain_set
+    )
+
+    selected_failure_types = frozenset(
+        item for item in selected_failure_raw
+        if item in _MAIL_DOMAIN_FAILURE_TYPES
+    )
+
+    effective_groups: tuple[tuple[str, ...], ...]
+    if not grouping_enabled:
+        effective_groups = (main_domains,) if main_domains else ()
+    elif group_mode == 'manual':
+        groups = _build_manual_domain_groups(list(main_domains), list(raw_groups))
+        effective_groups = tuple(tuple(group) for group in (groups if groups else ([list(main_domains)] if main_domains else [])))
+    else:
+        groups = _build_auto_domain_groups(list(main_domains), group_count)
+        effective_groups = tuple(tuple(group) for group in (groups if groups else ([list(main_domains)] if main_domains else [])))
+
+    _MAIL_DOMAIN_CONFIG_CACHE["key"] = cache_key
+    _MAIL_DOMAIN_CONFIG_CACHE["main_domains"] = main_domains
+    _MAIL_DOMAIN_CONFIG_CACHE["main_domain_set"] = main_domain_set
+    _MAIL_DOMAIN_CONFIG_CACHE["disabled_main_domains"] = disabled_main_domains
+    _MAIL_DOMAIN_CONFIG_CACHE["selected_failure_types"] = selected_failure_types
+    _MAIL_DOMAIN_CONFIG_CACHE["effective_groups"] = effective_groups
+    return _MAIL_DOMAIN_CONFIG_CACHE
+
+
+def _get_configured_main_domains() -> list[str]:
+    return list(_get_mail_domain_config_cache()["main_domains"])
+
+
+def get_configured_main_domains_snapshot() -> list[str]:
+    return list(_get_mail_domain_config_cache()["main_domains"])
+
+
+def _is_mail_domain_grouping_enabled() -> bool:
+    return bool(
+        is_mail_domain_runtime_control_enabled()
+        and getattr(cfg, 'ENABLE_MAIL_DOMAIN_GROUPING', False)
+    )
+
+
+def _get_mail_domain_group_strategy() -> str:
+    strategy = str(getattr(cfg, 'MAIL_DOMAIN_GROUP_STRATEGY', 'round_robin') or 'round_robin').strip().lower()
+    if strategy not in {'round_robin', 'exhaust_then_next'}:
+        return 'round_robin'
+    return strategy
+
+
+def _build_auto_domain_groups(main_domains: list[str], group_count: int) -> list[list[str]]:
+    if not main_domains or group_count <= 0:
+        return []
+    groups = [[] for _ in range(group_count)]
+    for index, domain in enumerate(main_domains):
+        groups[index % group_count].append(domain)
+    return [group for group in groups if group]
+
+
+def _build_manual_domain_groups(main_domains: list[str], raw_groups: list[Any]) -> list[list[str]]:
+    master_set = set(main_domains)
+    groups = []
+    assigned = set()
+    for raw_group in raw_groups:
+        group = []
+        for domain in _parse_mail_domain_items(raw_group):
+            if domain in master_set and domain not in assigned:
+                assigned.add(domain)
+                group.append(domain)
+        if group:
+            groups.append(group)
+    return groups
+
+
+def _get_effective_domain_groups(main_domains: list[str]) -> list[list[str]]:
+    normalized_domains = tuple(_normalize_main_domain(domain) for domain in main_domains)
+    cache = _get_mail_domain_config_cache()
+    cached_main_domains = cache["main_domains"]
+    if normalized_domains == cached_main_domains:
+        return [list(group) for group in cache["effective_groups"]]
+    if not _is_mail_domain_grouping_enabled():
+        return [list(normalized_domains)] if normalized_domains else []
+    group_count = max(1, min(10, int(getattr(cfg, 'MAIL_DOMAIN_GROUP_COUNT', 2) or 2)))
+    group_mode = str(getattr(cfg, 'MAIL_DOMAIN_GROUP_MODE', 'auto') or 'auto').strip().lower()
+    main_domain_list = [domain for domain in normalized_domains if domain]
+    if group_mode == 'manual':
+        groups = _build_manual_domain_groups(main_domain_list, getattr(cfg, 'MAIL_DOMAIN_GROUPS', []) or [])
+        return groups if groups else [main_domain_list]
+    groups = _build_auto_domain_groups(main_domain_list, group_count)
+    return groups if groups else [main_domain_list]
+
+
+def _get_mail_domain_group_label(domain: str) -> str:
+    normalized = _normalize_main_domain(domain)
+    if not normalized or not getattr(cfg, 'ENABLE_MAIL_DOMAIN_GROUPING', False):
+        return ""
+    groups = _get_mail_domain_config_cache()["effective_groups"]
+    for index, group in enumerate(groups):
+        if normalized in group:
+            return f"[{index + 1}]"
+    return ""
+
+
+def _format_grouped_mail_log(label: str, email: str) -> str:
+    group_label = _get_mail_domain_group_label(label)
+    masked_email = mask_email(email)
+    return f"{group_label} {masked_email}" if group_label else masked_email
 
 
 def _normalize_main_domain(domain: str) -> str:
@@ -132,7 +290,7 @@ def _normalize_main_domain(domain: str) -> str:
         if not text:
             return ""
 
-    configured = _get_configured_main_domains()
+    configured = _get_mail_domain_config_cache()["main_domains"]
     for root in configured:
         if text == root or text.endswith(f".{root}"):
             return root
@@ -140,12 +298,7 @@ def _normalize_main_domain(domain: str) -> str:
 
 
 def _get_disabled_main_domains() -> set[str]:
-    normalized = set()
-    for domain in getattr(cfg, 'DISABLED_MAIL_DOMAINS', []) or []:
-        root = _normalize_main_domain(domain)
-        if root:
-            normalized.add(root)
-    return normalized
+    return set(_get_mail_domain_config_cache()["disabled_main_domains"])
 
 
 def _all_configured_main_domains_disabled() -> bool:
@@ -191,6 +344,9 @@ def clear_mail_domain_runtime_stats() -> None:
         _DOMAIN_RUNTIME_SESSION["counting_enabled"] = False
         _DOMAIN_RUNTIME_SESSION["last_started_at"] = 0.0
         _DOMAIN_RUNTIME_SESSION["last_stopped_at"] = 0.0
+        _DOMAIN_RUNTIME_SESSION["tie_break_cursor"] = 0
+        _DOMAIN_RUNTIME_SESSION["group_cursor"] = 0
+        _DOMAIN_RUNTIME_SESSION["group_sticky_cursor"] = 0
 
 
 def _is_mail_domain_runtime_tracking_active() -> bool:
@@ -201,6 +357,7 @@ def _new_domain_runtime_state() -> dict:
     return {
         "fail_count": 0,
         "success_count": 0,
+        "pick_count": 0,
         "failure_counts": {},
         "last_failure_reason": "",
         "cooldown_until": 0.0,
@@ -212,10 +369,10 @@ def _new_domain_runtime_state() -> dict:
 
 
 def _prune_expired_domain_records(now: float) -> None:
-    expired_domains = [
-        domain for domain, state in _DOMAIN_RUNTIME_STATE.items()
-        if float(state.get("cooldown_until") or 0.0) > 0 and float(state.get("cooldown_until") or 0.0) <= now
-    ]
+    expired_domains = []
+    for domain, state in _DOMAIN_RUNTIME_STATE.items():
+        if float(state.get("cooldown_until") or 0.0) > 0 and float(state.get("cooldown_until") or 0.0) <= now:
+            expired_domains.append(domain)
     for domain in expired_domains:
         _DOMAIN_RUNTIME_STATE.pop(domain, None)
 
@@ -231,6 +388,178 @@ def _get_domain_state(domain: str) -> dict:
         state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
         return dict(state)
 
+def _get_domain_selection_key(state: dict) -> tuple[int, float]:
+    pick_count = max(0, int(state.get("pick_count") or 0))
+    last_used_at = float(state.get("last_used_at") or 0.0)
+    return pick_count, last_used_at
+
+
+def _select_low_failure_domain(candidates: list[str]) -> Optional[str]:
+    if not candidates:
+        return None
+
+    selected_failure_types = _get_selected_mail_domain_failure_types()
+    prioritized_clean = True
+    best_key = None
+    best_domains: list[str] = []
+
+    for domain in candidates:
+        state = _DOMAIN_RUNTIME_STATE.setdefault(domain, _new_domain_runtime_state())
+        fail_count = _recalculate_domain_fail_count(state, selected_failure_types)
+        domain_is_clean = fail_count <= 0
+        selection_key = _get_domain_selection_key(state)
+
+        if best_key is None:
+            prioritized_clean = domain_is_clean
+            best_key = selection_key
+            best_domains = [domain]
+            continue
+
+        if prioritized_clean and not domain_is_clean:
+            continue
+        if domain_is_clean and not prioritized_clean:
+            prioritized_clean = True
+            best_key = selection_key
+            best_domains = [domain]
+            continue
+        if selection_key < best_key:
+            best_key = selection_key
+            best_domains = [domain]
+            continue
+        if selection_key == best_key:
+            best_domains.append(domain)
+
+    if not best_domains:
+        return None
+    if len(best_domains) == 1:
+        return best_domains[0]
+
+    cursor = int(_DOMAIN_RUNTIME_SESSION.get("tie_break_cursor", 0) or 0)
+    selected = best_domains[cursor % len(best_domains)]
+    _DOMAIN_RUNTIME_SESSION["tie_break_cursor"] = cursor + 1
+    return selected
+
+
+def _mark_selected_domain_used(selected: Optional[str], now: float, increment: int = 1) -> Optional[str]:
+    if not selected:
+        return None
+    state = _DOMAIN_RUNTIME_STATE.setdefault(selected, _new_domain_runtime_state())
+    state["last_used_at"] = now
+    state["pick_count"] = max(0, int(state.get("pick_count") or 0)) + max(1, int(increment or 1))
+    return selected
+
+
+def _get_available_main_domain_candidates(main_domains: list[str], now: float) -> list[str]:
+    disabled_domains = _get_disabled_main_domains()
+    candidates = []
+    for domain in main_domains:
+        normalized = _normalize_main_domain(domain)
+        if not normalized or normalized in disabled_domains:
+            continue
+        state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+        cooldown_until = float(state.get("cooldown_until") or 0.0)
+        if cooldown_until > now:
+            continue
+        candidates.append(normalized)
+    return candidates
+
+
+def _select_round_robin_group_candidates(groups: list[list[str]], now: float) -> list[str]:
+    if not groups:
+        return []
+    cursor = int(_DOMAIN_RUNTIME_SESSION.get("group_cursor", 0) or 0)
+    if cursor >= len(groups) or cursor < 0:
+        cursor = 0
+    for offset in range(len(groups)):
+        group_index = (cursor + offset) % len(groups)
+        candidates = _get_available_main_domain_candidates(groups[group_index], now)
+        if candidates:
+            _DOMAIN_RUNTIME_SESSION["group_cursor"] = (group_index + 1) % len(groups)
+            return candidates
+    return []
+
+
+def _select_exhaust_then_next_group_candidates(groups: list[list[str]], now: float) -> list[str]:
+    if not groups:
+        return []
+    cursor = int(_DOMAIN_RUNTIME_SESSION.get("group_sticky_cursor", 0) or 0)
+    if cursor >= len(groups) or cursor < 0:
+        cursor = 0
+    current_candidates = _get_available_main_domain_candidates(groups[cursor], now)
+    if current_candidates:
+        _DOMAIN_RUNTIME_SESSION["group_sticky_cursor"] = cursor
+        return current_candidates
+    for offset in range(1, len(groups) + 1):
+        group_index = (cursor + offset) % len(groups)
+        candidates = _get_available_main_domain_candidates(groups[group_index], now)
+        if candidates:
+            _DOMAIN_RUNTIME_SESSION["group_sticky_cursor"] = group_index
+            return candidates
+    return []
+
+
+def _select_group_candidates_from_groups(groups: list[list[str]], now: float) -> list[str]:
+    if not groups:
+        return []
+    if _get_mail_domain_group_strategy() == 'exhaust_then_next':
+        return _select_exhaust_then_next_group_candidates(groups, now)
+    return _select_round_robin_group_candidates(groups, now)
+
+
+def _select_group_candidates(main_domains: list[str], now: float) -> list[str]:
+    groups = _get_effective_domain_groups(main_domains)
+    return _select_group_candidates_from_groups(groups, now)
+
+
+def _select_first_available_main_domain(main_domains: list[str], now: float, batch_size: int = 1) -> Optional[str]:
+    disabled_domains = _get_disabled_main_domains()
+    for domain in main_domains:
+        normalized = _normalize_main_domain(domain)
+        if not normalized or normalized in disabled_domains:
+            continue
+        state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
+        if float(state.get("cooldown_until") or 0.0) > now:
+            continue
+        return _mark_selected_domain_used(normalized, now, increment=batch_size)
+    return None
+
+
+
+def _select_main_domain_from_candidates(candidates: list[str]) -> Optional[str]:
+    if not candidates:
+        return None
+    if getattr(cfg, 'MAIL_DOMAIN_PREFER_LOW_FAILURE_MODE', False):
+        return _select_low_failure_domain(candidates)
+    return random.choice(candidates)
+
+
+def _preallocate_main_domains_locked(main_domains: list[str], batch_size: int, now: float) -> list[Optional[str]]:
+    allocated: list[Optional[str]] = []
+    batch_size = max(0, int(batch_size or 0))
+    if getattr(cfg, 'MAIL_DOMAIN_PINPOINT_BURST_MODE', False):
+        selected = _select_first_available_main_domain(main_domains, now, batch_size=batch_size)
+        return [selected] * batch_size if selected else [None] * batch_size
+
+    groups = _get_effective_domain_groups(main_domains) if _is_mail_domain_grouping_enabled() else []
+    batch_candidates = _select_group_candidates_from_groups(groups, now) if groups else _get_available_main_domain_candidates(main_domains, now)
+    enforce_unique_within_batch = len(set(batch_candidates)) >= batch_size
+    used_in_batch: set[str] = set()
+
+    for _ in range(batch_size):
+        candidates = list(batch_candidates)
+        if enforce_unique_within_batch:
+            candidates = [domain for domain in candidates if domain not in used_in_batch]
+        if not candidates:
+            allocated.append(None)
+            continue
+        selected = _select_main_domain_from_candidates(candidates)
+        marked = _mark_selected_domain_used(selected, now)
+        if marked:
+            used_in_batch.add(marked)
+        allocated.append(marked)
+    return allocated
+
+
 def pick_available_main_domain(main_domains: list[str]) -> Optional[str]:
     disabled_domains = _get_disabled_main_domains()
     if not is_mail_domain_runtime_control_enabled():
@@ -238,27 +567,27 @@ def pick_available_main_domain(main_domains: list[str]) -> Optional[str]:
         candidates = [domain for domain in normalized_domains if domain and domain not in disabled_domains]
         return random.choice(candidates) if candidates else None
 
-    candidates = []
     now = time.time()
 
     with _DOMAIN_RUNTIME_LOCK:
         _prune_expired_domain_records(now)
-        for domain in main_domains:
-            normalized = _normalize_main_domain(domain)
-            if not normalized or normalized in disabled_domains:
-                continue
-            state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
-            cooldown_until = float(state.get("cooldown_until") or 0.0)
-            if cooldown_until > now:
-                continue
-            candidates.append(normalized)
-
+        candidates = _select_group_candidates(main_domains, now) if _is_mail_domain_grouping_enabled() else _get_available_main_domain_candidates(main_domains, now)
         if not candidates:
             return None
+        selected = _select_main_domain_from_candidates(candidates)
+        return _mark_selected_domain_used(selected, now)
 
-        selected = random.choice(candidates)
-        _DOMAIN_RUNTIME_STATE[selected]["last_used_at"] = now
-        return selected
+
+def preallocate_main_domains_for_batch(main_domains: list[str], batch_size: int) -> list[Optional[str]]:
+    if batch_size <= 0:
+        return []
+    if not is_mail_domain_runtime_control_enabled():
+        return [None] * batch_size
+
+    now = time.time()
+    with _DOMAIN_RUNTIME_LOCK:
+        _prune_expired_domain_records(now)
+        return _preallocate_main_domains_locked(main_domains, batch_size, now)
 
 
 def _apply_domain_cooldown(state: dict, reason: str, cooldown_sec: int) -> float:
@@ -270,20 +599,15 @@ def _apply_domain_cooldown(state: dict, reason: str, cooldown_sec: int) -> float
 
 
 def _get_selected_mail_domain_failure_types() -> set[str]:
-    selected = {
-        str(item or "").strip().lower()
-        for item in (getattr(cfg, 'MAIL_DOMAIN_FAILURE_TYPES', []) or [])
-        if str(item or "").strip()
-    }
-    return {item for item in selected if item in _MAIL_DOMAIN_FAILURE_TYPES}
+    return set(_get_mail_domain_config_cache()["selected_failure_types"])
 
 
-def _recalculate_domain_fail_count(state: dict) -> int:
+def _recalculate_domain_fail_count(state: dict, selected_failure_types: Optional[set[str]] = None) -> int:
     failure_counts = state.get("failure_counts")
     if not isinstance(failure_counts, dict):
         failure_counts = {}
         state["failure_counts"] = failure_counts
-    selected = _get_selected_mail_domain_failure_types()
+    selected = selected_failure_types if selected_failure_types is not None else _get_selected_mail_domain_failure_types()
     fail_count = sum(
         max(0, int(failure_counts.get(reason) or 0))
         for reason in selected
@@ -297,6 +621,7 @@ def _build_domain_result(domain: str, state: dict, cooldown_until: float, cooldo
         "domain": domain,
         "fail_count": int(state.get("fail_count") or 0),
         "success_count": int(state.get("success_count") or 0),
+        "pick_count": max(0, int(state.get("pick_count") or 0)),
         "failure_counts": dict(state.get("failure_counts") or {}),
         "last_failure_reason": str(state.get("last_failure_reason") or ""),
         "cooldown_reason": str(state.get("cooldown_reason") or ""),
@@ -318,6 +643,7 @@ def record_domain_failure(domain: str, reason: str) -> dict:
 
     threshold = int(getattr(cfg, 'MAIL_DOMAIN_FAIL_THRESHOLD', 0) or 0)
     cooldown_sec = int(getattr(cfg, 'MAIL_DOMAIN_FAIL_COOLDOWN_SEC', 0) or 0)
+    selected_failure_types = _get_selected_mail_domain_failure_types()
     now = time.time()
 
     with _DOMAIN_RUNTIME_LOCK:
@@ -328,18 +654,19 @@ def record_domain_failure(domain: str, reason: str) -> dict:
             failure_counts = {}
             state["failure_counts"] = failure_counts
         cooldown_until = float(state.get("cooldown_until") or 0.0)
+        _recalculate_domain_fail_count(state, selected_failure_types)
         state["last_failure_at"] = now
         state["last_failure_reason"] = normalized_reason
 
         if cooldown_until > now:
-            _recalculate_domain_fail_count(state)
+            _recalculate_domain_fail_count(state, selected_failure_types)
             state["fail_count"] = 0
             if not state.get("cooldown_reason"):
                 state["cooldown_reason"] = normalized_reason
             return _build_domain_result(normalized, state, cooldown_until, False)
 
         failure_counts[normalized_reason] = int(failure_counts.get(normalized_reason) or 0) + 1
-        fail_count = _recalculate_domain_fail_count(state)
+        fail_count = _recalculate_domain_fail_count(state, selected_failure_types)
         cooldown_triggered = False
         if threshold > 0 and fail_count >= threshold:
             cooldown_until = _apply_domain_cooldown(state, normalized_reason, cooldown_sec)
@@ -354,6 +681,7 @@ def record_domain_success(domain: str) -> dict:
     if not normalized or not is_mail_domain_runtime_control_enabled() or not _is_mail_domain_runtime_tracking_active():
         return {}
 
+    selected_failure_types = _get_selected_mail_domain_failure_types()
     now = time.time()
 
     with _DOMAIN_RUNTIME_LOCK:
@@ -361,19 +689,20 @@ def record_domain_success(domain: str) -> dict:
         state = _DOMAIN_RUNTIME_STATE.setdefault(normalized, _new_domain_runtime_state())
         state["success_count"] = int(state.get("success_count") or 0) + 1
         state["last_success_at"] = now
-        _recalculate_domain_fail_count(state)
+        _recalculate_domain_fail_count(state, selected_failure_types)
         cooldown_until = float(state.get("cooldown_until") or 0.0)
         return _build_domain_result(normalized, state, cooldown_until, False)
 
 
 def _build_domain_runtime_row(domain: str, state: dict, now: float) -> dict:
     cooldown_until = float(state.get("cooldown_until") or 0.0)
-    is_disabled = is_mail_domain_disabled(domain)
-    _recalculate_domain_fail_count(state)
+    is_disabled = domain in _get_disabled_main_domains()
+    _recalculate_domain_fail_count(state, _get_selected_mail_domain_failure_types())
     return {
         "domain": domain,
         "fail_count": int(state.get("fail_count") or 0),
         "success_count": int(state.get("success_count") or 0),
+        "pick_count": max(0, int(state.get("pick_count") or 0)),
         "failure_counts": dict(state.get("failure_counts") or {}),
         "last_failure_reason": str(state.get("last_failure_reason") or ""),
         "cooldown_until": cooldown_until,
@@ -460,11 +789,9 @@ def clear_mail_domain_runtime_domain_counters(domain: str) -> dict:
         if not state:
             return {}
         state["fail_count"] = 0
-        state["success_count"] = 0
         state["failure_counts"] = {}
         state["last_failure_reason"] = ""
         state["last_failure_at"] = 0.0
-        state["last_success_at"] = 0.0
         return _get_domain_runtime_row_locked(normalized, now)
 
 
@@ -513,13 +840,33 @@ def get_mail_domain_runtime_stats() -> list[dict]:
         return []
 
     sync_mail_domain_runtime_state_with_config()
+    selected_failure_types = _get_selected_mail_domain_failure_types()
+    disabled_domains = _get_disabled_main_domains()
     now = time.time()
     rows = []
     with _DOMAIN_RUNTIME_LOCK:
         _prune_expired_domain_records(now)
         for domain in sorted(_DOMAIN_RUNTIME_STATE.keys()):
             state = _DOMAIN_RUNTIME_STATE[domain]
-            rows.append(_build_domain_runtime_row(domain, state, now))
+            cooldown_until = float(state.get("cooldown_until") or 0.0)
+            _recalculate_domain_fail_count(state, selected_failure_types)
+            rows.append({
+                "domain": domain,
+                "fail_count": int(state.get("fail_count") or 0),
+                "success_count": int(state.get("success_count") or 0),
+                "pick_count": max(0, int(state.get("pick_count") or 0)),
+                "failure_counts": dict(state.get("failure_counts") or {}),
+                "last_failure_reason": str(state.get("last_failure_reason") or ""),
+                "cooldown_until": cooldown_until,
+                "cooldown_remaining_sec": max(0, int(cooldown_until - now)) if cooldown_until > now else 0,
+                "cooldown_reason": str(state.get("cooldown_reason") or ""),
+                "is_available": cooldown_until <= now,
+                "is_disabled": domain in disabled_domains,
+                "is_enabled": domain not in disabled_domains,
+                "last_used_at": float(state.get("last_used_at") or 0.0),
+                "last_failure_at": float(state.get("last_failure_at") or 0.0),
+                "last_success_at": float(state.get("last_success_at") or 0.0),
+            })
     return rows
 
 
@@ -643,7 +990,12 @@ def _get_ai_data_package():
 #         return None, None
 #     return result
 
-def get_email_and_token(proxies: Any = None) -> tuple:
+def get_email_and_token(
+    proxies: Any = None,
+    assigned_domain: Optional[str] = None,
+    batch_id: Optional[int] = None,
+    worker_index: Optional[int] = None,
+) -> tuple:
 # def _raw_get_email_and_token(proxies: Any = None) -> tuple:
     """兼容五种邮箱模式的地址创建，返回 (email, token_or_id)。"""
     if getattr(cfg, 'GLOBAL_STOP', False): return None, None
@@ -932,6 +1284,9 @@ def get_email_and_token(proxies: Any = None) -> tuple:
     prefix, ai_enabled = _get_ai_data_package()
     use_domain_runtime_control = is_mail_domain_runtime_control_enabled(mode)
 
+    batch_preallocated = batch_id is not None and worker_index is not None
+    skip_domain_fallback = batch_preallocated and assigned_domain is None
+
     if cfg.ENABLE_SUB_DOMAINS:
         # sticky = getattr(_thread_data, 'sticky_domain', None)
         # if sticky:
@@ -943,7 +1298,10 @@ def get_email_and_token(proxies: Any = None) -> tuple:
             print(f"[{cfg.ts()}] [ERROR] 未配置主域名池，无法捏造子域！")
             return None, None
 
-        selected_main = pick_available_main_domain(main_list)
+        if skip_domain_fallback:
+            return None, None
+
+        selected_main = _normalize_main_domain(assigned_domain) if assigned_domain is not None else pick_available_main_domain(main_list)
         if not selected_main:
             if _all_configured_main_domains_disabled():
                 print(f"[{cfg.ts()}] [ERROR] 所有主域名均已被手动禁用，当前无法继续生成邮箱！")
@@ -975,7 +1333,9 @@ def get_email_and_token(proxies: Any = None) -> tuple:
         if not domain_list:
             print(f"[{cfg.ts()}] [ERROR] 域名池配置为空，无法生成邮箱！")
             return None, None
-        selected_domain = pick_available_main_domain(domain_list)
+        if skip_domain_fallback:
+            return None, None
+        selected_domain = _normalize_main_domain(assigned_domain) if assigned_domain is not None else pick_available_main_domain(domain_list)
         if not selected_domain:
             if _all_configured_main_domains_disabled():
                 print(f"[{cfg.ts()}] [ERROR] 所有主域名均已被手动禁用，当前无法继续生成邮箱！")
@@ -1002,7 +1362,9 @@ def get_email_and_token(proxies: Any = None) -> tuple:
 
     if mode == "cloudmail":
         if getattr(cfg, 'CM_LOCAL_WEBHOOK', False):
-            print(f"[{cfg.ts()}] [INFO] 成功通过 本项目收件模式 cloudmail 指定创建邮箱: {mask_email(email_str)}")
+            print(
+                f"[{cfg.ts()}] [INFO] 成功通过 本项目收件模式 cloudmail 指定创建邮箱: {mask_email(email_str)}"
+            )
             return email_str, ""
         else:
             token = get_cm_token(mail_proxies)
@@ -1040,7 +1402,9 @@ def get_email_and_token(proxies: Any = None) -> tuple:
                                         json={"email": email_str}, headers=headers,
                                         proxies=mail_proxies, verify=_ssl_verify(), timeout=15)
                     res.raise_for_status()
-                    print(f"[{cfg.ts()}] [INFO] 成功通过 Freemail 指定创建邮箱: {mask_email(email_str)}")
+                    print(
+                        f"[{cfg.ts()}] [INFO] 成功通过 Freemail 指定创建邮箱: {mask_email(email_str)}"
+                    )
                     return email_str, ""
                 except Exception as e:
                     print(f"[{cfg.ts()}] [ERROR] Freemail 邮箱创建异常: {e}")
@@ -1081,7 +1445,9 @@ def get_email_and_token(proxies: Any = None) -> tuple:
                     email = data["address"].strip()
                     jwt = data.get("jwt", "").strip()
                     set_last_email(email)
-                    print(f"[{cfg.ts()}] [INFO] cloudflare_temp_email成功获取临时邮箱: {mask_email(email)}")
+                    print(
+                        f"[{cfg.ts()}] [INFO] cloudflare_temp_email成功获取临时邮箱: {_format_grouped_mail_log(selected_domain, email)}"
+                    )
                     return email, jwt
                 terminal_failure_reason = "cloudflare_temp_email_network"
                 print(f"[{cfg.ts()}] [WARNING] cloudflare_temp_email邮箱申请失败 (尝试 {attempt + 1}/5): {res.text}")


### PR DESCRIPTION
## 概要

- 为黄金矿工模式增加域名分组与分组运行策略
- 补充分组信息在运行时面板与日志中的展示
- 修复批次域名预分配在常规 / CPA / Sub2API 路径下的一致性问题
- 优化低异常优先与运行时面板轮询相关开销

## 测试

- [x] `python -m py_compile c:/Users/Syfa/Desktop/wef/utils/email_providers/mail_service.py c:/Users/Syfa/Desktop/wef/utils/core_engine.py`
