### PR TITLE
fix(imap): handle HTML-only emails and exclude CSS color false positives in OTP extraction

### DIFF
--- a/utils/email_providers/mail_service.py
+++ b/utils/email_providers/mail_service.py
@@ -1548,7 +1548,7 @@ def _extract_otp_code(content: str) -> str:
         m = re.search(p, content)
         if m:
             return m.group(1)
-    fallback = re.search(r"(?<!\d)(\d{6})(?!\d)", content)
+    fallback = re.search(r"(?<![\d#])(\d{6})(?!\d)", content)
     return fallback.group(1) if fallback else ""
 
 
@@ -2258,8 +2258,25 @@ def get_oai_code(
                                                 content += part.get_payload(decode=True).decode("utf-8", "ignore")
                                             except Exception:
                                                 pass
+                                    if not content:
+                                        for part in msg.walk():
+                                            if part.get_content_type() == "text/html":
+                                                try:
+                                                    content += part.get_payload(decode=True).decode("utf-8", "ignore")
+                                                except Exception:
+                                                    pass
                                 else:
                                     content = msg.get_payload(decode=True).decode("utf-8", "ignore")
+                                if "<html" in content.lower() or "<div" in content.lower():
+                                    try:
+                                        from html.parser import HTMLParser as _HP
+                                        class _S(_HP):
+                                            def __init__(self): super().__init__(); self._t = []
+                                            def handle_data(self, d): self._t.append(d)
+                                            def get(self): return " ".join(self._t)
+                                        _p = _S(); _p.feed(content); content = _p.get()
+                                    except Exception:
+                                        pass
                                 to_h = str(msg.get("To", "")).lower()
                                 del_h = str(msg.get("Delivered-To", "")).lower()
                                 tgt = email.lower()


### PR DESCRIPTION
## Bug Description

When using IMAP mode to retrieve OpenAI verification codes, the system consistently returns `202123` instead of the real OTP code.

### Root Cause

OpenAI verification emails are **pure HTML** — they have no `text/plain` part, only `text/html`. The IMAP parsing code only attempted to read `text/plain`:

```python
if msg.is_multipart():
    for part in msg.walk():
        if part.get_content_type() == "text/plain":  # never matches
            content += ...
# content remains empty string ""
```

With `content = ""`, the precise patterns in `_extract_otp_code` all fail to match. The fallback regex `(?<!\d)(\d{6})(?!\d)` then runs against the **raw HTML**, where CSS color values like `#202123` appear throughout the email template. Since `#` is not a digit, the lookbehind `(?<!\d)` succeeds, and `202123` is returned as the OTP.

### Fixes

**Fix 1** — IMAP branch in `utils/email_providers/mail_service.py`:

After reading all `text/plain` parts, if `content` is still empty, fall back to `text/html` and strip tags:

```python
if not content:  # HTML fallback
    for part in msg.walk():
        if part.get_content_type() == "text/html":
            content += part.get_payload(decode=True).decode("utf-8", "ignore")
# Strip HTML tags before OTP extraction
if "<html" in content.lower() or "<div" in content.lower():
    from html.parser import HTMLParser as _HP
    class _S(_HP):
        def __init__(self): super().__init__(); self._t = []
        def handle_data(self, d): self._t.append(d)
        def get(self): return " ".join(self._t)
    _p = _S(); _p.feed(content); content = _p.get()
```

**Fix 2** — `_extract_otp_code` fallback regex:

Change `(?<!\d)` to `(?<![\d#])` so that 6-digit sequences preceded by `#` (CSS hex colors) are excluded:

```python
# Before
fallback = re.search(r"(?<!\d)(\d{6})(?!\d)", content)
# After  
fallback = re.search(r"(?<![\d#])(\d{6})(?!\d)", content)
```

### Testing

Verified against a real OpenAI verification email:
- Before fix: always returns `202123` (first CSS color `#202123` in the HTML template)
- After fix: correctly extracts the real 6-digit OTP from the email body text