### PR TITLE
增加可配置的集群账号上传超时

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -389,6 +389,7 @@ cf_api_email:
 #CF KEY
 cf_api_key:
 max_log_lines: "500"
+cluster_upload_timeout_sec: "15"
 #集群总控
 cluster_node_name: "NODE-1"
 cluster_master_url: ""

--- a/index.html
+++ b/index.html
@@ -4420,6 +4420,19 @@
                                         </p>
                                     </div>
 
+                                    <div class="bg-slate-50 p-5 md:p-6 rounded-2xl border border-slate-200 shadow-inner">
+                                        <label class="block text-slate-600 text-xs font-black uppercase tracking-wider mb-3 flex items-center">
+                                            <span>集群账号上传超时（秒）</span>
+                                            <span class="text-[10px] text-slate-400 font-normal ml-2 bg-white px-2 py-0.5 rounded border border-slate-200">控制节点向总控上传账号时的等待时长</span>
+                                        </label>
+                                        <div>
+                                            <input type="number" v-model.number="config.cluster_upload_timeout_sec" min="15" max="3600" class="w-full appearance-none bg-white border-2 border-slate-200 text-slate-800 font-bold rounded-xl py-3.5 px-4 focus:outline-none focus:ring-0 focus:border-slate-400 transition-colors shadow-sm text-base">
+                                        </div>
+                                        <p class="text-[11px] text-sky-700/80 mt-3 font-medium bg-sky-50 px-3 py-1.5 rounded-lg border border-sky-100 shadow-sm inline-block">
+                                            默认 15 秒，最小 15 秒，最大 3600 秒；输入过小会自动回到 15，超过 1 小时会自动限制为 3600。
+                                        </p>
+                                    </div>
+
                                     <div class="bg-amber-50/50 p-5 md:p-6 rounded-2xl border border-amber-200/60 shadow-inner">
                                         <label class="relative inline-flex items-center cursor-pointer group w-full">
                                             <input type="checkbox" v-model="config.disable_forced_takeover" class="sr-only peer">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1385,6 +1385,9 @@ createApp({
                 if (!this.config.max_log_lines) {
                     this.config.max_log_lines = 500;
                 }
+                let clusterUploadTimeout = parseInt(this.config.cluster_upload_timeout_sec, 10);
+                if (Number.isNaN(clusterUploadTimeout)) clusterUploadTimeout = 15;
+                this.config.cluster_upload_timeout_sec = Math.max(15, Math.min(3600, clusterUploadTimeout));
                 if (!this.config.temporam) {
                     this.config.temporam = { cookie: '' };
                 }
@@ -1795,6 +1798,9 @@ createApp({
                 )];
                 this.config.mail_domain_fail_threshold = Math.max(0, parseInt(this.config.mail_domain_fail_threshold, 10) || 0);
                 this.config.mail_domain_fail_cooldown_sec = Math.max(0, parseInt(this.config.mail_domain_fail_cooldown_sec, 10) || 0);
+                let clusterUploadTimeout = parseInt(this.config.cluster_upload_timeout_sec, 10);
+                if (Number.isNaN(clusterUploadTimeout)) clusterUploadTimeout = 15;
+                this.config.cluster_upload_timeout_sec = Math.max(15, Math.min(3600, clusterUploadTimeout));
                 this.config.warp_proxy_list = this.warpListStr.split('\n').map(s => s.trim()).filter(s => s);
                 if (!this.config.raw_proxy_pool || typeof this.config.raw_proxy_pool !== 'object' || Array.isArray(this.config.raw_proxy_pool)) {
                     this.config.raw_proxy_pool = { enable: false, proxy_list: [] };

--- a/utils/config.py
+++ b/utils/config.py
@@ -903,6 +903,7 @@ def reload_all_configs(new_config_dict=None):
     CLUSTER_NODE_NAME = str(_c.get("cluster_node_name", "")).strip()
     CLUSTER_MASTER_URL = str(_c.get("cluster_master_url", "")).strip().rstrip("/")
     CLUSTER_SECRET = str(_c.get("cluster_secret", "wenfxl666")).strip()
+    CLUSTER_UPLOAD_TIMEOUT_SEC = min(3600, safe_int(_c.get("cluster_upload_timeout_sec", 15), 15, minimum=15))
 
     REG_MODE = str(_c.get("reg_mode", "protocol")).strip().lower()
 

--- a/wfxl_openai_regst.py
+++ b/wfxl_openai_regst.py
@@ -335,7 +335,8 @@ def _worker_push_thread():
                                         upload_req = urllib.request.Request(
                                             f"{master_url.rstrip('/')}/api/cluster/upload_accounts", data=req_body,
                                             headers={'Content-Type': 'application/json'})
-                                        with opener.open(upload_req, timeout=15) as _:
+                                        upload_timeout = getattr(core_engine.cfg, 'CLUSTER_UPLOAD_TIMEOUT_SEC', 15)
+                                        with opener.open(upload_req, timeout=upload_timeout) as _:
                                             print(f"[{core_engine.ts()}] [系统] 📤 已成功将 {len(local_accounts)} 个账号打包发往总控！")
                                     except Exception as e:
                                         print(f"[{core_engine.ts()}] [ERROR] ❌ 账号上传总控失败: {e}")


### PR DESCRIPTION
## 概要
- 为集群账号上传增加可持久化的 `cluster_upload_timeout_sec` 配置项
- 在“杂项与安全控制”设置面板中新增超时输入框，并限制范围为 15 到 3600 秒
- 上传账号到总控时改为读取配置值，不再写死 15 秒超时

## 测试计划
- [x] 运行 `python -m py_compile \"wfxl_openai_regst.py\" \"utils/config.py\" \"routers/system_routes.py\"`
- [ ] 打开设置页面，确认新超时字段可以正常显示和保存
- [ ] 触发一次上传账号到总控，确认运行时使用的是配置后的超时时间

🤖 Generated with [Claude Code](https://claude.com/claude-code)