### PR TITLE
优化 H5 顶栏与日间导航样式

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <script src="/static/js/tailwind.min.js?v=20260511-12"></script>
     <script src="/static/js/vue.global.js?v=20260511-12"></script>
     <script src="/static/js/jszip.min.js?v=20260511-12"></script>
-
 </head>
 <body class="overflow-hidden bg-slate-50">
     <div id="app" v-cloak class="h-screen flex flex-col">
@@ -258,7 +257,22 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
                             </button>
                             <div class="console-mode-chip bg-indigo-50/80 text-indigo-700 font-bold tracking-wide border border-indigo-100/80 truncate shadow-sm flex items-center">
-                                模式: {{ t(stats.mode) }} <span class="hidden sm:inline opacity-30 mx-2">|</span> <span class="hidden sm:inline text-slate-500">成功</span> <span class="font-black ml-1 text-indigo-600">{{stats.success}}/{{stats.target}}</span> <span class="hidden lg:inline opacity-30 mx-2">|</span> <span class="hidden lg:inline text-slate-500">总 {{stats.total}}</span>
+                                <span class="console-mode-main">模式: {{ t(stats.mode) }}</span>
+                                <span class="hidden sm:inline opacity-30 mx-2">|</span>
+                                <span class="hidden sm:inline text-slate-500">成功</span>
+                                <span class="hidden sm:inline font-black ml-1 text-indigo-600">{{stats.success}}/{{stats.target}}</span>
+                                <span class="sm:hidden console-mode-mobile-success">
+                                    <span class="opacity-40 mx-1">|</span>
+                                    <span class="text-slate-500">成功</span>
+                                    <span class="font-black ml-1 text-indigo-600">{{stats.success}}/{{stats.target}}</span>
+                                </span>
+                                <span class="sm:hidden console-mode-mobile-total">
+                                    <span class="opacity-40 mx-1">|</span>
+                                    <span class="text-slate-500">总</span>
+                                    <span class="font-black ml-1 text-indigo-600">{{stats.total}}</span>
+                                </span>
+                                <span class="hidden lg:inline opacity-30 mx-2">|</span>
+                                <span class="hidden lg:inline text-slate-500">总 {{stats.total}}</span>
                             </div>
                             <div class="console-progress-wrap">
                                 <div class="text-sky-500 font-black text-xs md:text-sm whitespace-nowrap">{{stats.progress_pct}}</div>
@@ -270,7 +284,7 @@
 
                         <div class="console-topbar-actions">
                             <div v-if="config" class="console-mode-switch shrink-0">
-                                <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+                                <div class="flex items-center w-full">
                                     <div class="console-mode-switch-inner bg-slate-100 p-1 rounded-xl shadow-inner border border-slate-200 shrink-0">
                                         <button @click="changeRegMode('protocol')"
                                                 :class="['flex-1 py-1.5 md:py-2 px-2 md:px-3 rounded-lg text-xs md:text-sm font-bold transition-all whitespace-nowrap',
@@ -290,24 +304,24 @@
                                 <button @click="toggleTheme" class="console-toolbar-btn font-bold border transition-all active:scale-95 shrink-0 bg-white text-slate-700 border-slate-200 hover:bg-slate-50 shadow-sm flex items-center justify-center">
                                     <span v-if="isDarkMode" class="flex items-center gap-1.5">
                                         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                                        <span class="hidden sm:inline">日间</span>
+                                        <span>日间</span>
                                     </span>
                                     <span v-else class="flex items-center gap-1.5">
                                         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
-                                        <span class="hidden sm:inline">护眼</span>
+                                        <span>护眼</span>
                                     </span>
                                 </button>
                                 <button @click="toggleLanguage" class="console-toolbar-btn font-bold border transition-all active:scale-95 shrink-0 bg-white text-indigo-600 border-indigo-100 hover:bg-indigo-50 shadow-sm flex items-center justify-center gap-1.5">
                                     <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"></path></svg>
-                                    <span class="hidden sm:inline">{{ targetLanguageLabel() }}</span><span class="sm:hidden">{{ currentLanguage === 'zh-TW' ? '简' : '繁' }}</span>
+                                    <span>{{ targetLanguageLabel() }}</span>
                                 </button>
                                 <span v-if="isRunning" class="console-status-pill flex items-center gap-1.5 md:gap-2 text-emerald-600 font-bold bg-white border border-slate-200 shadow-sm shrink-0">
                                     <span class="w-1.5 h-1.5 md:w-2 md:h-2 bg-emerald-500 rounded-full animate-pulse shadow-[0_0_5px_rgba(16,185,129,0.8)]"></span>
-                                    <span class="hidden sm:inline">运行中</span><span class="sm:hidden">运行</span>
+                                    <span>运行中</span>
                                 </span>
                                 <span v-else class="console-status-pill flex items-center gap-1.5 md:gap-2 text-slate-500 font-bold bg-white border border-slate-200 shadow-sm shrink-0">
                                     <span class="w-1.5 h-1.5 md:w-2 md:h-2 bg-slate-400 rounded-full"></span>
-                                    <span class="hidden sm:inline">已停止</span><span class="sm:hidden">停止</span>
+                                    <span>已停止</span>
                                 </span>
                                 <button @click="toggleSystem"
                                         class="console-run-btn font-black text-white shadow-lg transition-all active:scale-95 shrink-0 flex items-center gap-1"

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -212,6 +212,21 @@
 	flex: 0 0 auto;
 	white-space: nowrap;
 }
+.console-mode-main {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.console-mode-mobile-total {
+	flex: 0 0 auto;
+	white-space: nowrap;
+}
+.console-mode-mobile-success {
+	flex: 0 0 auto;
+	white-space: nowrap;
+}
 .console-progress-wrap {
 	display: flex;
 	align-items: center;
@@ -299,64 +314,97 @@
 }
 @media (max-width: 767px) {
 	.console-topbar {
-		align-items: flex-start;
-		gap: 12px;
+		align-items: stretch;
+		gap: 6px;
+		flex-wrap: wrap;
+		padding-inline: 2px;
 	}
 	.console-topbar-primary {
 		width: 100%;
-		padding-right: 0;
-		gap: 10px;
-		flex-wrap: nowrap;
+		flex: 0 0 100%;
 		min-width: 0;
+		padding-right: 0;
+		gap: 6px;
+		flex-wrap: nowrap;
 	}
 	.console-mode-chip {
-		flex: 1 1 auto;
+		flex: 1 1 0;
+		width: 0;
 		max-width: none;
 		min-width: 0;
-		padding: 8px 12px;
-		font-size: 11px;
-		line-height: 1.25;
+		padding: 6px 8px;
+		font-size: 9px;
+		line-height: 1.2;
+		gap: 0;
 	}
 	.console-progress-wrap {
-		flex: 0 0 112px;
-		width: 112px;
-		max-width: 112px;
+		flex: 1 1 0;
+		width: 0;
+		max-width: none;
 		min-width: 0;
 		margin-left: 0;
-		gap: 8px;
+		gap: 4px;
 		padding-left: 0;
+	}
+	.console-progress-bar {
+		flex: 1 1 auto;
+		width: auto;
+	}
+	.console-mode-main {
+		font-size: 9px;
+	}
+	.console-mode-mobile-success,
+	.console-mode-mobile-total {
+		font-size: 8px;
+		margin-left: 4px;
 	}
 	.console-topbar-actions {
 		width: 100%;
-		gap: 10px;
+		flex: 0 0 100%;
+		flex-wrap: nowrap;
+		gap: 3px;
 		justify-content: flex-start;
-		align-items: flex-start;
+		align-items: center;
 	}
 	.console-mode-switch {
-		width: 88px;
-		flex: 0 0 88px;
+		width: auto;
+		flex: 1 1 0;
+		min-width: 0;
 	}
 	.console-mode-switch .flex {
-		width: auto;
+		width: 100%;
 	}
 	.console-mode-switch-inner {
 		width: 100%;
+		padding: 0;
 	}
 	.console-topbar-actions > .console-topbar-actions {
 		display: flex;
-		flex-wrap: wrap;
+		flex-wrap: nowrap;
+		flex: 4 1 0;
+		min-width: 0;
 		width: auto;
-		gap: 8px;
+		gap: 3px;
 	}
 	.console-toolbar-btn,
 	.console-status-pill,
 	.console-run-btn {
+		flex: 1 1 0;
 		width: auto;
-		min-width: 72px;
-		min-height: 40px;
+		min-width: 0;
+		min-height: 34px;
 		justify-content: center;
-		padding: 9px 12px;
-		border-radius: 16px;
+		padding: 4px 3px;
+		border-radius: 12px;
+		font-size: 7px;
+		column-gap: 2px;
+	}
+	.console-mode-switch-inner button {
+		display: flex !important;
+		width: 100%;
+		justify-content: center;
+		padding: 4px 3px !important;
+		font-size: 7px !important;
 	}
 	.console-meta-strip {
 		gap: 6px 8px;
@@ -536,6 +584,18 @@
 .mobile-nav-drawer.is-open {
 	transform: translateX(0);
 	box-shadow: 0 18px 50px rgba(15, 23, 42, 0.22);
+}
+body:not(.theme-dark) .mobile-nav-mask {
+	background: rgba(15, 23, 42, 0.52);
+	backdrop-filter: none;
+}
+body:not(.theme-dark) .mobile-nav-drawer {
+	background: #f1f5f9 !important;
+	backdrop-filter: none !important;
+	border-right-color: #cbd5e1 !important;
+	box-shadow:
+		inset -1px 0 0 rgba(148, 163, 184, 0.24),
+		0 14px 32px rgba(15, 23, 42, 0.08);
 }
 body.theme-dark .inventory-shell {
 	background: linear-gradient(180deg, rgba(18, 24, 33, 0.98), rgba(12, 19, 30, 0.96));


### PR DESCRIPTION
## 变更内容
- 优化 H5 顶栏信息排布，补回手机端的成功数、总数与进度百分比展示
- 调整 H5 第一排模式区与进度条的宽度分配，减少模式信息被截断的情况
- 调整 H5 第二排控制按钮的宽度与内边距分配，让协议按钮与其他按钮显示更均衡
- 修复日间模式下移动端导航抽屉与遮罩的毛玻璃透明感，改为实色背景

## 说明
- 仅涉及前端样式与展示逻辑调整
- 不涉及后端接口、数据结构与业务流程修改