### PR TITLE
feat(sms): add per-provider proxy toggle for SmsBower / HeroSMS / 5SIM

### DIFF
--- a/index.html
+++ b/index.html
@@ -2523,6 +2523,11 @@
                                             <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-rose-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
                                             <span class="ml-4 text-sm font-black text-rose-900 tracking-wide">账号创建时接码 <span class="text-xs font-medium text-rose-600/80 block mt-0.5">(注: 仅创建拦截有效,非拿OAuth时)</span></span>
                                         </label>
+                                        <label class="relative inline-flex items-center p-4 bg-blue-50/50 rounded-xl border border-blue-200 shadow-sm cursor-pointer hover:bg-blue-100/50 transition-colors group">
+                                            <input type="checkbox" v-model="config.hero_sms.use_proxy" class="sr-only peer">
+                                            <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-blue-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
+                                            <span class="ml-4 text-sm font-black text-blue-900 tracking-wide">API 走代理 <span class="text-xs font-medium text-blue-600/80 block mt-0.5">(关闭则直连 HeroSMS，不经过代理)</span></span>
+                                        </label>
                                     </div>
                                 </div>
                             </div>
@@ -2685,6 +2690,11 @@
                                             <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-rose-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
                                             <span class="ml-4 text-sm font-black text-rose-900 tracking-wide">账号创建时接码 <span class="text-xs font-medium text-rose-600/80 block mt-0.5">(注: 仅创建拦截有效)</span></span>
                                         </label>
+                                        <label class="relative inline-flex items-center p-4 bg-blue-50/50 rounded-xl border border-blue-200 shadow-sm cursor-pointer hover:bg-blue-100/50 transition-colors group">
+                                            <input type="checkbox" v-model="config.smsbower.use_proxy" class="sr-only peer">
+                                            <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-blue-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
+                                            <span class="ml-4 text-sm font-black text-blue-900 tracking-wide">API 走代理 <span class="text-xs font-medium text-blue-600/80 block mt-0.5">(关闭则直连 SmsBower，不经过代理)</span></span>
+                                        </label>
                                     </div>
                                 </div>
                             </div>
@@ -2844,6 +2854,11 @@
                                             <input type="checkbox" v-model="config.fivesim.verify_on_register" class="sr-only peer">
                                             <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-rose-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
                                             <span class="ml-4 text-sm font-black text-rose-900 tracking-wide">账号创建时接码 <span class="text-xs font-medium text-rose-600/80 block mt-0.5">(注: 仅创建拦截有效)</span></span>
+                                        </label>
+                                        <label class="relative inline-flex items-center p-4 bg-blue-50/50 rounded-xl border border-blue-200 shadow-sm cursor-pointer hover:bg-blue-100/50 transition-colors group">
+                                            <input type="checkbox" v-model="config.fivesim.use_proxy" class="sr-only peer">
+                                            <div class="relative w-11 h-6 shrink-0 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all after:shadow-sm peer-checked:bg-blue-500 shadow-inner transition-colors duration-300 group-hover:shadow-md"></div>
+                                            <span class="ml-4 text-sm font-black text-blue-900 tracking-wide">API 走代理 <span class="text-xs font-medium text-blue-600/80 block mt-0.5">(关闭则直连 5SIM，不经过代理)</span></span>
                                         </label>
                                     </div>
                                 </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1317,6 +1317,7 @@ createApp({
                         this.config.smsbower.reuse_phone = normalizeBooleanLike(this.config.smsbower.reuse_phone, true);
                         this.config.smsbower.verify_on_register = normalizeBooleanLike(this.config.smsbower.verify_on_register, false);
                         if(this.config.smsbower.reuse_max === undefined) this.config.smsbower.reuse_max = 2;
+                        if(this.config.smsbower.use_proxy === undefined) this.config.smsbower.use_proxy = false;
                     }
 
                     if (!this.config.fivesim) {
@@ -1327,11 +1328,13 @@ createApp({
                         };
                     } else {
                         if(this.config.fivesim.reuse_max === undefined) this.config.fivesim.reuse_max = 2;
+                        if(this.config.fivesim.use_proxy === undefined) this.config.fivesim.use_proxy = false;
                     }
 
                     if (this.config.hero_sms) {
                         this.config.hero_sms.enabled = normalizeBooleanLike(this.config.hero_sms.enabled, false);
                         if(this.config.hero_sms.reuse_max === undefined) this.config.hero_sms.reuse_max = 2;
+                        if(this.config.hero_sms.use_proxy === undefined) this.config.hero_sms.use_proxy = false;
                     }
                 }
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -322,6 +322,7 @@ SMSBOWER_MAX_TRIES = 3
 SMSBOWER_POLL_TIMEOUT_SEC = 180
 SMSBOWER_MIN_PRICE = 0.05
 SMSBOWER_OPERATOR = ""
+SMSBOWER_USE_PROXY = False
 
 # 5SIM
 FIVESIM_ENABLED = False
@@ -470,7 +471,7 @@ def reload_all_configs(new_config_dict=None):
     global GMAIL_OAUTH_SUFFIX_MODE, GMAIL_OAUTH_SUFFIX_LEN_MIN, GMAIL_OAUTH_SUFFIX_LEN_MAX
     global DISABLE_FORCED_TAKEOVER
     global SMSBOWER_ENABLED, SMSBOWER_API_KEY, SMSBOWER_BASE_URL, SMSBOWER_COUNTRY, SMSBOWER_SERVICE
-    global SMSBOWER_AUTO_PICK_COUNTRY, SMSBOWER_VERIFY_ON_REGISTER, SMSBOWER_REUSE_PHONE, SMSBOWER_OPERATOR
+    global SMSBOWER_AUTO_PICK_COUNTRY, SMSBOWER_VERIFY_ON_REGISTER, SMSBOWER_REUSE_PHONE, SMSBOWER_OPERATOR, SMSBOWER_USE_PROXY
     global SMSBOWER_MAX_PRICE, SMSBOWER_MIN_BALANCE, SMSBOWER_MAX_TRIES, SMSBOWER_POLL_TIMEOUT_SEC, SMSBOWER_MIN_PRICE
     global FIVESIM_ENABLED, FIVESIM_API_KEY, FIVESIM_SERVICE, FIVESIM_COUNTRY
     global FIVESIM_AUTO_PICK_COUNTRY, FIVESIM_VERIFY_ON_REGISTER, FIVESIM_REUSE_PHONE
@@ -817,6 +818,7 @@ def reload_all_configs(new_config_dict=None):
     HERO_SMS_AUTO_PICK_COUNTRY = _hero_sms_conf.get("auto_pick_country", False)
     HERO_SMS_REUSE_PHONE = _hero_sms_conf.get("reuse_phone", True)
     HERO_SMS_VERIFY_ON_REGISTER = _hero_sms_conf.get("verify_on_register", False)
+    HERO_SMS_USE_PROXY = safe_bool(_hero_sms_conf.get("use_proxy", False), default=False)
     HERO_SMS_REUSE_MAX = safe_int(_hero_sms_conf.get("reuse_max", 2), default=2)
 
     try:
@@ -855,6 +857,7 @@ def reload_all_configs(new_config_dict=None):
     SMSBOWER_MIN_PRICE = safe_float(_smsbower.get("min_price", 0.05), default=0.05)
     SMSBOWER_REUSE_MAX = safe_int(_smsbower.get("reuse_max", 2), default=2)
     SMSBOWER_OPERATOR = str(_smsbower.get("operator", ) or "").strip()
+    SMSBOWER_USE_PROXY = safe_bool(_smsbower.get("use_proxy", False), default=False)
 
     _fivesim = _c.get("fivesim", {})
     FIVESIM_ENABLED = safe_bool(_fivesim.get("enabled", False), default=False)
@@ -863,6 +866,7 @@ def reload_all_configs(new_config_dict=None):
     FIVESIM_COUNTRY = str(_fivesim.get("country") or "any").strip()
     FIVESIM_AUTO_PICK_COUNTRY = safe_bool(_fivesim.get("auto_pick_country", True), default=True)
     FIVESIM_VERIFY_ON_REGISTER = safe_bool(_fivesim.get("verify_on_register", False), default=False)
+    FIVESIM_USE_PROXY = safe_bool(_fivesim.get("use_proxy", False), default=False)
     FIVESIM_REUSE_PHONE = safe_bool(_fivesim.get("reuse_phone", True), default=True)
     FIVESIM_MAX_PRICE = safe_float(_fivesim.get("max_price", 50.0), default=50.0)
     FIVESIM_MIN_PRICE = safe_float(_fivesim.get("min_price", 0.0), default=0.0)

--- a/utils/integrations/fivesim_sms.py
+++ b/utils/integrations/fivesim_sms.py
@@ -148,6 +148,8 @@ def _fivesim_reuse_clear():
 
 def _fivesim_request(method: str, endpoint: str, proxies: Any, params: dict = None, json_data: dict = None) -> tuple[
     bool, str, Any]:
+    if not getattr(cfg, "FIVESIM_USE_PROXY", False):
+        proxies = None
     key = _fivesim_api_key()
     if not key: return False, "NO_KEY", None
 

--- a/utils/integrations/hero_sms.py
+++ b/utils/integrations/hero_sms.py
@@ -610,6 +610,8 @@ def _hero_sms_request(
         params: Optional[Dict[str, Any]] = None,
         timeout: int = 25,
 ) -> tuple[bool, str, Any]:
+    if not getattr(cfg, "HERO_SMS_USE_PROXY", False):
+        proxies = None
     key = _hero_sms_api_key()
     if not key:
         return False, "NO_KEY", None

--- a/utils/integrations/smsbower_sms.py
+++ b/utils/integrations/smsbower_sms.py
@@ -261,6 +261,8 @@ def _smsbower_country_score(country_id: int, *, cost: float, count: int, preferr
 def _smsbower_request(action: str, *, proxies: Any, params: Optional[Dict[str, Any]] = None, timeout: int = 25) -> \
 tuple[bool, str, Any]:
     key = _smsbower_api_key()
+    if not getattr(cfg, "SMSBOWER_USE_PROXY", False):
+        proxies = None
     if not key: return False, "NO_KEY", None
     query: Dict[str, Any] = {"action": str(action or "").strip(), "api_key": key}
     if params:


### PR DESCRIPTION
## Summary

SMS provider API calls (SmsBower, HeroSMS, 5SIM) currently inherit the global `DEFAULT_PROXY` setting. This means users who need a proxy for OpenAI registration but want direct access to SMS APIs (or vice versa) have no way to control this independently.

This PR adds a **per-provider proxy toggle** for all three SMS integrations.

## Changes

### Backend - `utils/config.py`
Added three new config keys:
- `smsbower.use_proxy` (default: `false`)
- `hero_sms.use_proxy` (default: `false`)
- `fivesim.use_proxy` (default: `false`)

### Backend - SMS integrations
Each provider's core request function now checks its own config before using proxies:

`utils/integrations/smsbower_sms.py` - `_smsbower_request()`:
```python
if not getattr(cfg, "SMSBOWER_USE_PROXY", False):
    proxies = None
```

`utils/integrations/hero_sms.py` - `_hero_sms_request()`:
```python
if not getattr(cfg, "HERO_SMS_USE_PROXY", False):
    proxies = None
```

`utils/integrations/fivesim_sms.py` - `_fivesim_request()`:
```python
if not getattr(cfg, "FIVESIM_USE_PROXY", False):
    proxies = None
```

### Frontend - `index.html` + `static/js/app.js`
Added an "API 走代理" toggle switch at the bottom of each SMS provider's config card:
- Blue toggle, styled consistently with existing switches
- Default: **off** (direct connect)

## Behavior

| Toggle | OFF (default) | ON |
|--------|-------------|-----|
| SmsBower API 走代理 | Direct connection to SmsBower | Uses DEFAULT_PROXY |
| HeroSMS API 走代理 | Direct connection to HeroSMS | Uses DEFAULT_PROXY |
| 5SIM API 走代理 | Direct connection to 5SIM | Uses DEFAULT_PROXY |

Note: The proxy toggle only affects the SMS provider API requests. The OpenAI OAuth flow during phone verification still uses the registration proxy as before.

## Config example

```yaml
smsbower:
  use_proxy: false

hero_sms:
  use_proxy: false

fivesim:
  use_proxy: false
```
