### PR TITLE
调整零阈值仓管补货逻辑

### DIFF
--- a/index.html
+++ b/index.html
@@ -3840,6 +3840,7 @@
                                         <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm hover:border-emerald-300 transition-colors">
                                             <label class="block text-[11px] text-slate-500 font-black mb-2 uppercase tracking-wider">库存报警阈值</label>
                                             <input type="number" v-model.number="config.cpa_mode.min_accounts_threshold" class="w-full appearance-none bg-slate-50 border-none text-slate-800 font-black text-xl md:text-2xl rounded-lg py-2 px-3 focus:outline-none focus:ring-0 transition-colors text-center shadow-inner">
+                                            <p class="text-[11px] text-slate-400 mt-2 font-medium leading-relaxed">设为 0 时将跳过库存巡检，直接按单次补发量执行补货，不再获取云端全量账号数据。</p>
                                         </div>
                                         <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm hover:border-emerald-300 transition-colors">
                                             <label class="block text-[11px] text-emerald-600 font-black mb-2 uppercase tracking-wider">单次补发量</label>
@@ -3965,6 +3966,7 @@
                                         <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm hover:border-purple-300 transition-colors">
                                             <label class="block text-[11px] text-slate-500 font-black mb-2 uppercase tracking-wider">库存报警阈值</label>
                                             <input type="number" v-model.number="config.sub2api_mode.min_accounts_threshold" class="w-full appearance-none bg-slate-50 border-none text-slate-800 font-black text-xl md:text-2xl rounded-lg py-2 px-3 focus:outline-none focus:ring-0 transition-colors text-center shadow-inner">
+                                            <p class="text-[11px] text-slate-400 mt-2 font-medium leading-relaxed">设为 0 时将跳过库存巡检，直接按单次补发量执行补货，不再获取云端全量账号数据。</p>
                                         </div>
                                         <div class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm hover:border-purple-300 transition-colors">
                                             <label class="block text-[11px] text-purple-600 font-black mb-2 uppercase tracking-wider">单次补发量</label>

--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -1279,7 +1279,11 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event, executor=None):
 
     while not async_stop_event.is_set() and not cfg.POOL_EXHAUSTED:
         try:
-            if cfg.CPA_AUTO_CHECK:
+            if cfg.MIN_ACCOUNTS_THRESHOLD <= 0:
+                total_files = 0
+                valid_count = 0
+                print(f"\n[{ts()}] [INFO] CPA 库存报警阈值为 0，跳过云端库存获取，直接按单次补发量执行补货。")
+            elif cfg.CPA_AUTO_CHECK:
                 valid_count, total_files = await perform_cpa_check(args, async_stop_event, loop, executor=executor)
             else:
                 print(f"\n[{ts()}] [INFO] 自动测活已关闭，直接读取云端列表进行补发判断...")
@@ -1299,12 +1303,16 @@ async def cpa_main_loop(args, async_stop_event: asyncio.Event, executor=None):
                 valid_count = total_files
                 print(f"[{ts()}] [INFO] 当前云端总数: {total_files} (未开启自动巡检，默认全部视为有效)")
 
-            if valid_count < cfg.MIN_ACCOUNTS_THRESHOLD:
+
+            if cfg.MIN_ACCOUNTS_THRESHOLD <= 0 or valid_count < cfg.MIN_ACCOUNTS_THRESHOLD:
                 need_to_reg          = cfg.BATCH_REG_COUNT
                 global run_stats
                 run_stats["target"] += need_to_reg
                 success_in_this_cycle = 0
-                print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.MIN_ACCOUNTS_THRESHOLD})，启动补货...")
+                if cfg.MIN_ACCOUNTS_THRESHOLD <= 0:
+                    print(f"[{ts()}] [INFO] 已禁用库存判断，直接启动补货 {need_to_reg} 个...")
+                else:
+                    print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.MIN_ACCOUNTS_THRESHOLD})，启动补货...")
                 await asyncio.sleep(1)
 
                 def _cpa_worker(worker_index=0, assigned_domain=None, batch_id=None):
@@ -1471,7 +1479,11 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
     while not async_stop_event.is_set() and not cfg.POOL_EXHAUSTED:
 
         try:
-            if cfg.SUB2API_AUTO_CHECK:
+            if cfg.SUB2API_MIN_THRESHOLD <= 0:
+                total_files = 0
+                valid_count = 0
+                print(f"\n[{ts()}] [INFO] Sub2API 库存报警阈值为 0，跳过云端库存获取，直接按单次补发量执行补货。")
+            elif cfg.SUB2API_AUTO_CHECK:
                 print(f"\n[{ts()}] [INFO] 开始执行 Sub2API 仓库例行巡检与测活...")
                 success, account_list = client.get_all_accounts()
                 if not success:
@@ -1526,12 +1538,15 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
                 valid_count = total_files
                 print(f"[{ts()}] [INFO] 当前云端总数: {total_files} (未开启自动巡检，默认全部视为有效)")
 
-            if valid_count < cfg.SUB2API_MIN_THRESHOLD:
+            if cfg.SUB2API_MIN_THRESHOLD <= 0 or valid_count < cfg.SUB2API_MIN_THRESHOLD:
                 need_to_reg          = cfg.SUB2API_BATCH_COUNT
                 global run_stats
                 run_stats["target"] += need_to_reg
                 success_in_this_cycle = 0
-                print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.SUB2API_MIN_THRESHOLD})，启动补货...")
+                if cfg.SUB2API_MIN_THRESHOLD <= 0:
+                    print(f"[{ts()}] [INFO] 已禁用库存判断，直接启动 Sub2API 补货 {need_to_reg} 个...")
+                else:
+                    print(f"[{ts()}] [INFO] 库存不足 ({valid_count} < {cfg.SUB2API_MIN_THRESHOLD})，启动补货...")
                 await asyncio.sleep(1)
 
                 def _sub2api_run_wrapper(p, skip_switch, assigned_domain=None, batch_id=None, worker_index=None):


### PR DESCRIPTION
## Summary
- 解决sub2api仓管,多实例同时拉取账号数据,导致sub2api部署机爆cpu
- update CPA 仓管逻辑：库存阈值为 0 时跳过全量库存拉取，直接按单次补发量补货
- update Sub2API 仓管逻辑：库存阈值为 0 时跳过全量账号拉取，直接按单次补发量补货
- update 前端提示文案，明确 0 阈值时的实际行为

## Test plan
- [x] 运行 `python -m py_compile utils/core_engine.py`
- [ ] 在 CPA 模式下将库存阈值设为 0，确认启动后直接进入补货且不拉取全量库存
- [ ] 在 Sub2API 模式下将库存阈值设为 0，确认启动后直接进入补货且不拉取全量账号

🤖 Generated with [Claude Code](https://claude.com/claude-code)