### PR TITLE
Mark cloud push status after auto sync

### DIFF
--- a/utils/core_engine.py
+++ b/utils/core_engine.py
@@ -717,6 +717,10 @@ def handle_registration_result(result: Any, cpa_upload: bool = False, run_ctx: d
                 success, up_msg = upload_to_cpa_integrated(token_data, cfg.CPA_API_URL, cfg.CPA_API_TOKEN)
                 if success:
                     print(f"[{ts()}] [SUCCESS] 补货凭证 {mask_email(account_email)} 云端上传成功！")
+                    try:
+                        db_manager.update_account_push_info([account_email], "CPA", mode="sync")
+                    except Exception:
+                        pass
                 else:
                     print(f"[{ts()}] [ERROR] 云端上传失败: {up_msg}")
 
@@ -1603,7 +1607,12 @@ async def sub2api_main_loop(args, async_stop_event: asyncio.Event, executor=None
                         else:
                             if hasattr(client, "add_account"):
                                 ok, msg = client.add_account(token_dict)
-                                if ok: print(f"[{ts()}] [SUCCESS] Sub2API 补货入库成功")
+                                if ok:
+                                    print(f"[{ts()}] [SUCCESS] Sub2API 补货入库成功")
+                                    try:
+                                        db_manager.update_account_push_info([token_dict.get("email", "")], "SUB2API", mode="sync")
+                                    except Exception:
+                                        pass
                                 else: print(f"[{ts()}] [ERROR] Sub2API 补货入库失败: {msg}")
                     return status
 
@@ -1827,6 +1836,10 @@ def handle_oauth_upgrade_result(email: str, result: Any, run_ctx: dict = None) -
             success, up_msg = upload_to_cpa_integrated(token_data, cfg.CPA_API_URL, cfg.CPA_API_TOKEN)
             if success:
                 print(f"[{ts()}] [SUCCESS] [提权] 凭证 {mask_email(email)} 已同步至 CPA 云端！")
+                try:
+                    db_manager.update_account_push_info([email], "CPA", mode="sync")
+                except Exception:
+                    pass
             else:
                 print(f"[{ts()}] [ERROR] [提权] 云端上传失败: {up_msg}")
 
@@ -1840,6 +1853,10 @@ def handle_oauth_upgrade_result(email: str, result: Any, run_ctx: dict = None) -
                 ok, msg = client.add_account(token_data)
                 if ok:
                     print(f"[{ts()}] [SUCCESS] [提权] 凭证 {mask_email(email)} 已同步至 Sub2API")
+                    try:
+                        db_manager.update_account_push_info([email], "SUB2API", mode="sync")
+                    except Exception:
+                        pass
                 else:
                     print(f"[{ts()}] [ERROR] [提权] Sub2API 补货入库失败: {msg}")
 


### PR DESCRIPTION
## 更新内容

本次修复的是仓管自动补货/提权同步成功后，本地账号库未同步标记云端推送状态的问题。之前手动推送会写入 `push_platform`，但自动路径成功上传后只打印日志，导致前端仍可能显示为“未推送”。

具体改动：

- CPA 仓管自动补货：`upload_to_cpa_integrated(...)` 上传成功后，写入本地 `push_platform=CPA`。
- Sub2API 仓管自动补货：`client.add_account(...)` 入库成功后，写入本地 `push_platform=SUB2API`。
- OAuth 提权后同步 CPA：同步成功后补写本地 `CPA` 推送标记。
- OAuth 提权后同步 Sub2API：同步成功后补写本地 `SUB2API` 推送标记。
- 标记更新使用 `mode="sync"`，避免账号同时推送到多个平台时覆盖已有平台标记。
- DB 写入包在 `try/except` 中，避免本地状态回写异常影响已成功完成的云端上传/入库流程。

## 影响

- 新注册并自动补货成功的账号，会正确从“未推送”变为已推送对应平台。
- 已有的手动推送逻辑不变。
- 半成品状态 `image2api` / `仅注册成功` 仍保持跳过云端同步，不会误标记。

## 验证

- 已运行：`python -m unittest discover -s tests -p test_sub2api_proxy_pool.py`
- 结果：`Ran 5 tests ... OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)